### PR TITLE
Share files directly from native share sheet

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -107,6 +107,18 @@
           "savePhotosPermission": "AlterSend saves received images and videos to your photo library.",
           "isAccessMediaLocationEnabled": false
         }
+      ],
+      [
+        "expo-share-intent",
+        {
+          "iosAppGroupIdentifier": "group.com.altersend.mobile",
+          "iosActivationRules": {
+            "NSExtensionActivationSupportsImageWithMaxCount": 100,
+            "NSExtensionActivationSupportsMovieWithMaxCount": 100,
+            "NSExtensionActivationSupportsFileWithMaxCount": 100
+          },
+          "androidIntentFilters": ["*/*"]
+        }
       ]
     ],
     "extra": {

--- a/apps/mobile/app/+native-intent.ts
+++ b/apps/mobile/app/+native-intent.ts
@@ -1,0 +1,12 @@
+import { getShareExtensionKey } from 'expo-share-intent'
+
+export function redirectSystemPath({ path }: { path: string; initial: boolean }) {
+  try {
+    if (path.includes(`dataUrl=${getShareExtensionKey()}`)) {
+      return '/'
+    }
+    return path
+  } catch {
+    return '/'
+  }
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -20,6 +20,7 @@ import { mobileApi } from '../src/api/mobileApi'
 import { ToastProvider } from '../src/components/Toast'
 import { startAppStateBridge } from '../src/lifecycle/appStateBridge'
 import { startDeepLinkHandler } from '../src/lifecycle/deepLinkHandler'
+import { ShareIntentHandler } from '../src/lifecycle/ShareIntentHandler'
 import { startPhotosCopyEffect } from '../src/transfer/receive'
 import { initSentry, captureException } from '../src/sentry'
 
@@ -99,6 +100,7 @@ export default function RootLayout() {
             }}
           >
             <ToastProvider>
+              <ShareIntentHandler />
               <ThemedStack />
             </ToastProvider>
           </ErrorBoundary>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -53,6 +53,7 @@
     "expo-linking": "~55.0.13",
     "expo-media-library": "~55.0.15",
     "expo-router": "~55.0.5",
+    "expo-share-intent": "^6.1.0",
     "expo-sharing": "~55.0.18",
     "expo-system-ui": "~55.0.9",
     "lucide-react-native": "^1.8.0",

--- a/apps/mobile/src/lifecycle/ShareIntentHandler.tsx
+++ b/apps/mobile/src/lifecycle/ShareIntentHandler.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { router } from 'expo-router'
+import { useShareIntent } from 'expo-share-intent'
+import { replaceSelectedFiles, continueShare, type SelectedFile } from '@altersend/domain'
+
+function toFilePath(path: string): string {
+  return path.startsWith('file://') ? path.slice('file://'.length) : path
+}
+
+export function ShareIntentHandler() {
+  const { hasShareIntent, shareIntent, resetShareIntent } = useShareIntent()
+
+  useEffect(() => {
+    if (!hasShareIntent || !shareIntent.files?.length) return
+
+    const files: SelectedFile[] = shareIntent.files.map((f) => ({
+      name: f.fileName ?? f.path.split('/').pop() ?? 'file',
+      path: toFilePath(f.path),
+      size: f.size ?? undefined
+    }))
+
+    replaceSelectedFiles(files)
+    router.navigate('/send')
+    void continueShare(files)
+    resetShareIntent()
+  }, [hasShareIntent, shareIntent, resetShareIntent])
+
+  return null
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "altersend",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -102,6 +103,7 @@
     },
     "apps/mobile": {
       "name": "@altersend/mobile",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -124,6 +126,7 @@
         "expo-linking": "~55.0.13",
         "expo-media-library": "~55.0.15",
         "expo-router": "~55.0.5",
+        "expo-share-intent": "^6.1.0",
         "expo-sharing": "~55.0.18",
         "expo-system-ui": "~55.0.9",
         "lucide-react-native": "^1.8.0",
@@ -15364,6 +15367,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-share-intent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/expo-share-intent/-/expo-share-intent-6.1.0.tgz",
+      "integrity": "sha512-cyGJjpA6ImNR641hj3J1Li/+jcD1ByPvLjgA93s8/ajkAAq42DMZvLi5RzmsWEhX0lBedva+fEhLNGCo+LpWMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/achorein"
+        },
+        "https://www.buymeacoffee.com/achorein"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~55.0.6",
+        "expo-constants": "~55.0.7",
+        "expo-linking": "~55.0.7"
+      },
+      "peerDependencies": {
+        "expo": "^55",
+        "expo-constants": ">=55.0.7",
+        "expo-linking": ">=55.0.7",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-sharing": {

--- a/packages/domain/src/transfer/commands.ts
+++ b/packages/domain/src/transfer/commands.ts
@@ -74,6 +74,11 @@ export const addSelectedFiles = (files: SelectedFile[]): void => {
   dispatchToTransferStore({ type: 'add_selected_files', files })
 }
 
+export const replaceSelectedFiles = (files: SelectedFile[]): void => {
+  dispatchToTransferStore({ type: 'clear_send_draft' })
+  if (files.length > 0) dispatchToTransferStore({ type: 'add_selected_files', files })
+}
+
 export const removeSelectedFile = (path: string): void => {
   dispatchToTransferStore({ type: 'remove_selected_file', path })
 }


### PR DESCRIPTION
## Summary

Adds "Share to AlterSend" support so users can send media straight from the native share sheet (Photos, Files, etc.) instead of opening the app and picking files manually.