### PR TITLE
Prepare v1.1: Add desktop webcam QR scanning + mobile fixes

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -19,6 +19,6 @@
 	<key>com.apple.security.device.audio-input</key>
 	<false/>
 	<key>com.apple.security.device.camera</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/apps/desktop/electron-builder.mac.json
+++ b/apps/desktop/electron-builder.mac.json
@@ -28,7 +28,10 @@
     "hardenedRuntime": true,
     "gatekeeperAssess": false,
     "entitlements": "build/entitlements.mac.plist",
-    "entitlementsInherit": "build/entitlements.mac.plist"
+    "entitlementsInherit": "build/entitlements.mac.plist",
+    "extendInfo": {
+      "NSCameraUsageDescription": "AlterSend uses your camera to scan a sender's connection QR code."
+    }
   },
   "afterSign": "scripts/notarize.cjs",
   "afterPack": "scripts/afterPack.cjs",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@altersend/desktop",
   "productName": "AlterSend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "upgrade": "pear://qxenz5wmspmryjc13m9yzsqj1conqotn8fb4ocbufwtz9mtbqq5o",
   "description": "Peer-to-peer file transfer. No servers, no accounts.",
   "license": "Apache-2.0",
@@ -28,9 +28,9 @@
     "dist:linux:arm64": "npx electron-builder --linux --arm64 -c electron-builder.linux.json --publish never"
   },
   "dependencies": {
-    "@altersend/components": "1.0.0",
-    "@altersend/core": "1.0.0",
-    "@altersend/domain": "1.0.0",
+    "@altersend/components": "1.1.0",
+    "@altersend/core": "1.1.0",
+    "@altersend/domain": "1.1.0",
     "@sentry/electron": "^7.13.0",
     "b4a": "^1.8.0",
     "bare-rpc": "^1.2.0",
@@ -43,6 +43,7 @@
     "paparam": "^1.10.0",
     "pear-runtime": "^1.1.1",
     "pear-runtime-updater": "^3.0.10",
+    "qr-scanner": "^1.4.2",
     "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/apps/desktop/src/electron/ipc.ts
+++ b/apps/desktop/src/electron/ipc.ts
@@ -1,4 +1,12 @@
-import { BrowserWindow, dialog, ipcMain, shell, type OpenDialogOptions } from 'electron'
+import {
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  shell,
+  systemPreferences,
+  type OpenDialogOptions
+} from 'electron'
+import { isMac } from 'which-runtime'
 import { stat } from 'fs/promises'
 import path from 'path'
 import { isPathSafe, type TransferMethod } from '@altersend/core'
@@ -145,5 +153,13 @@ export function registerIpcHandlers(runtime: DesktopRuntime) {
 
   ipcMain.handle('sentry:setEnabled', (_evt, enabled: boolean) => {
     setReportingEnabled(enabled)
+  })
+
+  // macOS gates camera access behind TCC; request it lazily when the user opens the
+  // webcam scanner. Other platforms grant via the OS/renderer prompt, so report ready.
+  ipcMain.handle('app:requestCameraAccess', async () => {
+    if (!isMac) return true
+    if (systemPreferences.getMediaAccessStatus('camera') === 'granted') return true
+    return systemPreferences.askForMediaAccess('camera')
   })
 }

--- a/apps/desktop/src/electron/preload.cjs
+++ b/apps/desktop/src/electron/preload.cjs
@@ -44,4 +44,5 @@ contextBridge.exposeInMainWorld('bridge', {
     return () => ipcRenderer.removeListener('app:deep-link', listener)
   },
   setSentryEnabled: (enabled) => ipcRenderer.invoke('sentry:setEnabled', enabled),
+  requestCameraAccess: () => ipcRenderer.invoke('app:requestCameraAccess'),
 })

--- a/apps/desktop/src/electron/window.ts
+++ b/apps/desktop/src/electron/window.ts
@@ -32,6 +32,13 @@ export async function createMainWindow(pear: PearRuntimeInstance) {
     }
   })
 
+  const allowedPermissions = new Set(['media', 'clipboard-sanitized-write'])
+  const { session } = win.webContents
+  session.setPermissionRequestHandler((_wc, permission, callback) =>
+    callback(allowedPermissions.has(permission))
+  )
+  session.setPermissionCheckHandler((_wc, permission) => allowedPermissions.has(permission))
+
   const showWindow = () => {
     if (!win.isDestroyed() && !win.isVisible()) win.show()
   }

--- a/apps/desktop/src/renderer/api/bridgeApi.ts
+++ b/apps/desktop/src/renderer/api/bridgeApi.ts
@@ -75,5 +75,8 @@ export const bridgeApi = {
   },
   setSentryEnabled(enabled: boolean) {
     return requireBridge().setSentryEnabled(enabled)
+  },
+  requestCameraAccess() {
+    return requireBridge().requestCameraAccess()
   }
 }

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: file:; font-src 'self' data:; connect-src 'self' https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: file:; font-src 'self' data:; connect-src 'self' https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io;" />
     <title>AlterSend</title>
   </head>
   <body class="m-0 h-full w-full overflow-hidden bg-background p-0 font-sans text-sm text-text-primary antialiased">

--- a/apps/desktop/src/renderer/pages/ReceivePage/ReceiveJoinView.tsx
+++ b/apps/desktop/src/renderer/pages/ReceivePage/ReceiveJoinView.tsx
@@ -1,13 +1,20 @@
 import { useState, type ChangeEvent } from 'react'
 import { Button, Input } from '@altersend/components'
+import { ChevronRightIcon, QrCodeIcon } from '@altersend/components/icons'
 import { isValidJoinCode, joinSession, useTransferStore } from '@altersend/domain'
+import { WebcamScanView } from './WebcamScanView'
 
 export function ReceiveJoinView() {
   const [joinKey, setJoinKey] = useState('')
   const [showValidation, setShowValidation] = useState(false)
   const [isJoining, setIsJoining] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
+  const [mode, setMode] = useState<'paste' | 'scan'>('paste')
   const storeError = useTransferStore((s) => s.errorMessage)
+
+  if (mode === 'scan') {
+    return <WebcamScanView onCancel={() => setMode('paste')} />
+  }
 
   const trimmedJoinKey = joinKey.trim()
   const isValidJoinKey = isValidJoinCode(trimmedJoinKey)
@@ -30,8 +37,30 @@ export function ReceiveJoinView() {
   }
 
   return (
-    <div className='flex h-full w-full min-w-0 flex-col overflow-y-auto pr-1'>
-      <div>
+    <div className='flex w-full flex-col gap-4'>
+      <button
+        className='group flex w-full items-center gap-3 rounded-[12px] border border-border-primary bg-background-subtle p-3 text-left transition-colors hover:border-border-strong hover:bg-surface-hover disabled:opacity-50'
+        disabled={isJoining}
+        onClick={() => setMode('scan')}
+        type='button'
+      >
+        <span className='flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-info/15 text-info'>
+          <QrCodeIcon size={18} />
+        </span>
+        <span className='min-w-0 flex-1'>
+          <span className='block text-[13.5px] font-semibold text-text-primary'>Scan QR code</span>
+          <span className='block text-[12px] leading-snug text-text-muted'>
+            Use the webcam to read the sender’s QR
+          </span>
+        </span>
+        <span className='shrink-0 text-text-muted transition-transform group-hover:translate-x-0.5'>
+          <ChevronRightIcon size={16} />
+        </span>
+      </button>
+
+      <div className='py-0.5 text-center text-[12px] text-text-muted'>or paste code</div>
+
+      <div className='flex flex-col gap-3.5'>
         <Input
           autoCapitalize='none'
           autoComplete='off'
@@ -50,12 +79,12 @@ export function ReceiveJoinView() {
           type='text'
           value={joinKey}
         />
-      </div>
 
-      <div className='mt-3'>
-        <Button disabled={isJoining} onClick={() => void join()} size='sm' variant='primary'>
-          {isJoining ? 'Connecting…' : 'Connect'}
-        </Button>
+        <div>
+          <Button disabled={isJoining} onClick={() => void join()} size='sm' variant='primary'>
+            {isJoining ? 'Connecting…' : 'Connect'}
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/pages/ReceivePage/WebcamScanView.tsx
+++ b/apps/desktop/src/renderer/pages/ReceivePage/WebcamScanView.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useRef, useState } from 'react'
+import QrScanner from 'qr-scanner'
+import { Button } from '@altersend/components'
+import { ChevronDownIcon } from '@altersend/components/icons'
+import { extractJoinCode, joinSession } from '@altersend/domain'
+import { bridgeApi } from '../../api/bridgeApi'
+
+interface WebcamScanViewProps {
+  onCancel: () => void
+}
+
+type ScanState = 'starting' | 'scanning' | 'connecting' | 'denied' | 'no-camera' | 'failed'
+
+const CAMERA_ERROR_STATES: Record<string, ScanState> = {
+  NotAllowedError: 'denied',
+  SecurityError: 'denied',
+  NotFoundError: 'no-camera',
+  OverconstrainedError: 'no-camera'
+}
+
+export function WebcamScanView({ onCancel }: WebcamScanViewProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const scannerRef = useRef<QrScanner | null>(null)
+  const handledRef = useRef(false)
+  const [state, setState] = useState<ScanState>('starting')
+  const [cameras, setCameras] = useState<QrScanner.Camera[]>([])
+  const [activeCamera, setActiveCamera] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [retryNonce, setRetryNonce] = useState(0)
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+    const controller = new AbortController()
+    const { signal } = controller
+    handledRef.current = false
+
+    const onResult = async (result: QrScanner.ScanResult) => {
+      if (handledRef.current) return
+      const joinCode = extractJoinCode(result.data)
+      if (!joinCode) return
+      
+      handledRef.current = true
+      void scannerRef.current?.stop()
+      setState('connecting')
+
+      try {
+        await joinSession(joinCode)
+      } catch (error) {
+        if (signal.aborted) return
+        handledRef.current = false
+        setErrorMessage(error instanceof Error ? error.message : 'Could not join the session.')
+        setState('scanning')
+        void scannerRef.current?.start()
+      }
+    }
+
+    const scanner = new QrScanner(video, (result) => void onResult(result), {
+      preferredCamera: 'environment',
+      highlightScanRegion: false,
+      highlightCodeOutline: false,
+      maxScansPerSecond: 8,
+      returnDetailedScanResult: true
+    })
+    scannerRef.current = scanner
+
+    const start = async () => {
+      try {
+        if (!(await bridgeApi.requestCameraAccess())) {
+          signal.throwIfAborted()
+          setState('denied')
+          return
+        }
+        if (!(await QrScanner.hasCamera())) {
+          signal.throwIfAborted()
+          setState('no-camera')
+          return
+        }
+
+        await scanner.start()
+        signal.throwIfAborted()
+
+        setState('scanning')
+        const list = await QrScanner.listCameras(true)
+
+        signal.throwIfAborted()
+        setCameras(list)
+
+        const stream = video.srcObject
+        const activeId =
+          stream instanceof MediaStream
+            ? stream.getVideoTracks()[0]?.getSettings().deviceId
+            : undefined
+        if (activeId) setActiveCamera(activeId)
+      } catch (error) {
+        if (signal.aborted) return
+        const mapped = error instanceof Error ? CAMERA_ERROR_STATES[error.name] : undefined
+        if (mapped) {
+          setState(mapped)
+        } else {
+          setErrorMessage(error instanceof Error ? error.message : 'Camera unavailable.')
+          setState('failed')
+        }
+      }
+    }
+    void start()
+
+    return () => {
+      controller.abort()
+      void scanner.stop()
+      scanner.destroy()
+      scannerRef.current = null
+    }
+  }, [retryNonce])
+
+  const retry = () => {
+    setErrorMessage(null)
+    setState('starting')
+    setRetryNonce((n) => n + 1)
+  }
+
+  const switchCamera = async (id: string) => {
+    const previous = activeCamera
+    setActiveCamera(id)
+    try {
+      await scannerRef.current?.setCamera(id)
+    } catch {
+      setActiveCamera(previous)
+    }
+  }
+
+  const blockedMessages: Partial<Record<ScanState, { title: string; hint: string }>> = {
+    denied: {
+      title: 'Camera access blocked',
+      hint: 'Allow camera access for AlterSend in your system settings, then try again. You can also paste the code instead.'
+    },
+    'no-camera': {
+      title: 'No camera found',
+      hint: 'Connect a webcam to scan, or paste the connection code instead.'
+    },
+    failed: {
+      title: 'Camera unavailable',
+      hint: errorMessage ?? 'The camera could not be started. Paste the connection code instead.'
+    }
+  }
+  const blocked = blockedMessages[state] ?? null
+
+  return (
+    <div className='flex h-full w-full min-w-0 flex-col overflow-y-auto pr-1'>
+      {blocked ? (
+        <div className='mx-auto w-full max-w-[400px] rounded-[16px] border border-border-primary bg-background-subtle p-5'>
+          <span className='block text-[15px] font-semibold text-text-primary'>{blocked.title}</span>
+          <p className='m-0 mt-1.5 text-[13px] leading-relaxed text-text-muted'>{blocked.hint}</p>
+          <div className='mt-4 flex items-center gap-2.5'>
+            <Button onClick={retry} size='sm' variant='primary'>
+              Try again
+            </Button>
+            <Button onClick={onCancel} size='sm' variant='secondary'>
+              Paste code instead
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className='flex w-full flex-col gap-5 sm:flex-row sm:items-start'>
+          <div className='relative aspect-square w-full max-w-[380px] shrink-0 overflow-hidden rounded-[16px] border border-border-primary bg-scrim'>
+            <video ref={videoRef} className='h-full w-full object-cover' muted playsInline />
+
+            {state === 'scanning' ? (
+              <div className='pointer-events-none absolute inset-0 flex items-center justify-center'>
+                <div
+                  className='relative aspect-square w-[80%]'
+                  style={{
+                    boxShadow: '0 0 0 9999px color-mix(in oklab, var(--as-color-scrim) 30%, transparent)'
+                  }}
+                >
+                  <span className='absolute left-0 top-0 h-7 w-7 rounded-tl-[12px] border-l-[3px] border-t-[3px] border-text-primary' />
+                  <span className='absolute right-0 top-0 h-7 w-7 rounded-tr-[12px] border-r-[3px] border-t-[3px] border-text-primary' />
+                  <span className='absolute bottom-0 left-0 h-7 w-7 rounded-bl-[12px] border-b-[3px] border-l-[3px] border-text-primary' />
+                  <span className='absolute bottom-0 right-0 h-7 w-7 rounded-br-[12px] border-b-[3px] border-r-[3px] border-text-primary' />
+                </div>
+              </div>
+            ) : null}
+
+            {state === 'starting' || state === 'connecting' ? (
+              <div className='absolute inset-0 flex flex-col items-center justify-center gap-2 bg-scrim/55 text-center'>
+                <span className='text-[14px] font-medium text-on-accent'>
+                  {state === 'connecting' ? 'Connecting…' : 'Starting camera…'}
+                </span>
+                {state === 'connecting' ? (
+                  <span className='text-[12px] text-on-accent/75'>Joining the sender’s session.</span>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
+          <div className='flex min-w-0 flex-1 flex-col gap-4'>
+            <p className='m-0 text-[13px] leading-relaxed text-text-muted'>
+              Point the sender’s QR code at the webcam — AlterSend connects automatically.
+            </p>
+
+            {errorMessage ? (
+              <p className='m-0 text-[12px] leading-relaxed text-danger'>{errorMessage}</p>
+            ) : null}
+
+            {cameras.length > 1 ? (
+              <div className='flex flex-col gap-1.5'>
+                <span className='text-[12px] font-medium text-text-secondary'>Camera</span>
+                <div className='relative'>
+                  <select
+                    aria-label='Camera'
+                    className='w-full cursor-pointer appearance-none rounded-[10px] border border-border-primary bg-background-subtle py-3 pl-4 pr-10 text-[13px] text-text-primary transition-colors hover:border-border-strong focus:border-border-strong focus:outline-none'
+                    onChange={(e) => void switchCamera(e.currentTarget.value)}
+                    value={activeCamera ?? undefined}
+                  >
+                    {cameras.map((cam) => (
+                      <option key={cam.id} value={cam.id}>
+                        {cam.label || 'Camera'}
+                      </option>
+                    ))}
+                  </select>
+                  <span className='pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-muted'>
+                    <ChevronDownIcon size={16} />
+                  </span>
+                </div>
+              </div>
+            ) : null}
+
+            <div className='flex'>
+              <Button onClick={onCancel} size='sm' variant='secondary'>
+                Paste code instead
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/pages/ReceivePage/WebcamScanView.tsx
+++ b/apps/desktop/src/renderer/pages/ReceivePage/WebcamScanView.tsx
@@ -39,7 +39,7 @@ export function WebcamScanView({ onCancel }: WebcamScanViewProps) {
       if (handledRef.current) return
       const joinCode = extractJoinCode(result.data)
       if (!joinCode) return
-      
+
       handledRef.current = true
       void scannerRef.current?.stop()
       setState('connecting')
@@ -170,7 +170,8 @@ export function WebcamScanView({ onCancel }: WebcamScanViewProps) {
                 <div
                   className='relative aspect-square w-[80%]'
                   style={{
-                    boxShadow: '0 0 0 9999px color-mix(in oklab, var(--as-color-scrim) 30%, transparent)'
+                    boxShadow:
+                      '0 0 0 9999px color-mix(in oklab, var(--as-color-scrim) 30%, transparent)'
                   }}
                 >
                   <span className='absolute left-0 top-0 h-7 w-7 rounded-tl-[12px] border-l-[3px] border-t-[3px] border-text-primary' />
@@ -187,7 +188,9 @@ export function WebcamScanView({ onCancel }: WebcamScanViewProps) {
                   {state === 'connecting' ? 'Connecting…' : 'Starting camera…'}
                 </span>
                 {state === 'connecting' ? (
-                  <span className='text-[12px] text-on-accent/75'>Joining the sender’s session.</span>
+                  <span className='text-[12px] text-on-accent/75'>
+                    Joining the sender’s session.
+                  </span>
                 ) : null}
               </div>
             ) : null}

--- a/apps/desktop/src/types.d.ts
+++ b/apps/desktop/src/types.d.ts
@@ -72,6 +72,7 @@ declare global {
     openFile: (filePath: string) => Promise<string>
     openExternalUrl: (url: string) => Promise<void>
     setSentryEnabled: (enabled: boolean) => Promise<void>
+    requestCameraAccess: () => Promise<boolean>
   }
 
   interface Window {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "AlterSend",
     "slug": "altersend",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "newArchEnabled": true,
     "orientation": "portrait",
     "scheme": "altersend",

--- a/apps/mobile/app/(tabs)/send/index.tsx
+++ b/apps/mobile/app/(tabs)/send/index.tsx
@@ -1,43 +1,38 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect } from 'react'
 import { View } from 'react-native'
 import { Button } from '@altersend/components'
 import { Layout } from '@/src/components'
 import { SelectFilesView } from '@/src/transfer/send'
-import { useRouter } from 'expo-router'
+import { usePathname, useRouter } from 'expo-router'
 import { getSendPageCopy, getSendStep, isShareStep, useTransferStore } from '@altersend/domain'
-import { clearSenderFlow, continueShare } from '@altersend/domain'
-
-type FlowTarget = 'select' | 'preparing' | 'share'
+import { continueShare } from '@altersend/domain'
 
 function NavigationController() {
   const router = useRouter()
+  const pathname = usePathname()
   const connectionState = useTransferStore((s) => s.connectionState)
   const draftPhase = useTransferStore((s) => s.draftPhase)
   const step = getSendStep({ draftPhase, isPeerConnected: connectionState === 'peer-connected' })
-  const prevTarget = useRef<FlowTarget>('select')
 
   useEffect(() => {
-    const target: FlowTarget =
-      step === 'preparing' ? 'preparing' : isShareStep(step) ? 'share' : 'select'
+    const target =
+      step === 'preparing' ? '/send/preparing' : isShareStep(step) ? '/send/share' : '/send'
 
-    if (prevTarget.current === target) return
+    if (pathname === target) return
 
-    const prev = prevTarget.current
-    prevTarget.current = target
-
-    if (target === 'preparing') {
-      router.push('/send/preparing')
-    } else if (target === 'share') {
-      if (prev === 'preparing') {
-        router.replace('/send/share')
-      } else {
-        router.push('/send/share')
-      }
-    } else if (prev !== 'select') {
-      clearSenderFlow()
-      if (router.canDismiss()) router.dismissAll()
+    if (target === '/send/preparing') {
+      if (pathname === '/send') router.push('/send/preparing')
+      else router.replace('/send/preparing')
+    } else if (target === '/send/share') {
+      if (pathname === '/send') router.push('/send/share')
+      else router.replace('/send/share')
+    } else if (
+      (pathname === '/send/preparing' || pathname === '/send/share') &&
+      router.canDismiss()
+    ) {
+      router.dismissAll()
     }
-  }, [step, router])
+  }, [step, pathname, router])
 
   return null
 }

--- a/apps/mobile/app/send/preparing.tsx
+++ b/apps/mobile/app/send/preparing.tsx
@@ -2,11 +2,11 @@ import { useCallback, useEffect } from 'react'
 import { Pressable } from 'react-native'
 import { useTheme } from '@altersend/components'
 import { ArrowLeftIcon } from '@altersend/components/icons'
-import { getSendPageCopy, getSendStep, useTransferStore } from '@altersend/domain'
+import { getSendPageCopy, getSendStep, isShareStep, useTransferStore } from '@altersend/domain'
 import { clearSenderFlow } from '@altersend/domain'
 import { Layout } from '@/src/components'
 import { PreparingView } from '@/src/transfer/send'
-import { useNavigation } from 'expo-router'
+import { useNavigation, useRouter } from 'expo-router'
 
 export default function SendPreparingScreen() {
   const { theme } = useTheme()
@@ -15,6 +15,11 @@ export default function SendPreparingScreen() {
   const step = getSendStep({ draftPhase, isPeerConnected: connectionState === 'peer-connected' })
   const copy = getSendPageCopy(step)
   const navigation = useNavigation()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (isShareStep(step)) router.replace('/send/share')
+  }, [step, router])
 
   const handleBack = useCallback(() => {
     clearSenderFlow()

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@altersend/mobile",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AlterSend mobile app (React Native / Expo)",
   "main": "expo-router/entry",
   "scripts": {
@@ -34,9 +34,9 @@
   },
   "homepage": "https://github.com/denislupookov/altersend#readme",
   "dependencies": {
-    "@altersend/components": "1.0.0",
-    "@altersend/core": "1.0.0",
-    "@altersend/domain": "1.0.0",
+    "@altersend/components": "1.1.0",
+    "@altersend/core": "1.1.0",
+    "@altersend/domain": "1.1.0",
     "@expo/vector-icons": "^15.0.2",
     "@sentry/react-native": "^8.11.0",
     "b4a": "^1.6.7",

--- a/apps/mobile/src/components/Layout/Layout.tsx
+++ b/apps/mobile/src/components/Layout/Layout.tsx
@@ -54,11 +54,14 @@ export const Layout = ({
               hitSlop={12}
               style={({ pressed }) => [styles.menuButton, { opacity: pressed ? 0.6 : 1 }]}
             >
-              <BlurView
-                intensity={Platform.OS === 'ios' ? 30 : 0}
-                tint='systemUltraThinMaterialDark'
-                style={StyleSheet.absoluteFill}
-              />
+              {Platform.OS === 'ios' ? (
+                <BlurView
+                  pointerEvents='none'
+                  intensity={30}
+                  tint='systemUltraThinMaterialDark'
+                  style={StyleSheet.absoluteFill}
+                />
+              ) : null}
               <View
                 style={[styles.menuButtonBorder, { borderColor: theme.colors.colorBorderPrimary }]}
               />

--- a/apps/mobile/src/lifecycle/ShareIntentHandler.tsx
+++ b/apps/mobile/src/lifecycle/ShareIntentHandler.tsx
@@ -1,7 +1,13 @@
 import { useEffect } from 'react'
 import { router } from 'expo-router'
 import { useShareIntent } from 'expo-share-intent'
-import { replaceSelectedFiles, continueShare, type SelectedFile } from '@altersend/domain'
+import {
+  clearSession,
+  continueShare,
+  replaceSelectedFiles,
+  useTransferStore,
+  type SelectedFile
+} from '@altersend/domain'
 
 function toFilePath(path: string): string {
   return path.startsWith('file://') ? path.slice('file://'.length) : path
@@ -19,10 +25,15 @@ export function ShareIntentHandler() {
       size: f.size ?? undefined
     }))
 
-    replaceSelectedFiles(files)
-    router.navigate('/send')
-    void continueShare(files)
     resetShareIntent()
+
+    void (async () => {
+      if (useTransferStore.getState().role !== null) await clearSession()
+      if (router.canDismiss()) router.dismissAll()
+      router.navigate('/send')
+      replaceSelectedFiles(files)
+      await continueShare(files)
+    })()
   }, [hasShareIntent, shareIntent, resetShareIntent])
 
   return null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "altersend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "altersend",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -31,12 +31,12 @@
     },
     "apps/desktop": {
       "name": "@altersend/desktop",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@altersend/components": "1.0.0",
-        "@altersend/core": "1.0.0",
-        "@altersend/domain": "1.0.0",
+        "@altersend/components": "1.1.0",
+        "@altersend/core": "1.1.0",
+        "@altersend/domain": "1.1.0",
         "@sentry/electron": "^7.13.0",
         "b4a": "^1.8.0",
         "bare-rpc": "^1.2.0",
@@ -49,6 +49,7 @@
         "paparam": "^1.10.0",
         "pear-runtime": "^1.1.1",
         "pear-runtime-updater": "^3.0.10",
+        "qr-scanner": "^1.4.2",
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -105,13 +106,13 @@
     },
     "apps/mobile": {
       "name": "@altersend/mobile",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@altersend/components": "1.0.0",
-        "@altersend/core": "1.0.0",
-        "@altersend/domain": "1.0.0",
+        "@altersend/components": "1.1.0",
+        "@altersend/core": "1.1.0",
+        "@altersend/domain": "1.1.0",
         "@expo/vector-icons": "^15.0.2",
         "@sentry/react-native": "^8.11.0",
         "b4a": "^1.6.7",
@@ -9490,6 +9491,12 @@
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
     },
     "node_modules/@types/pg": {
       "version": "8.15.6",
@@ -22574,6 +22581,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/qr-scanner": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/qr-scanner/-/qr-scanner-1.4.2.tgz",
+      "integrity": "sha512-kV1yQUe2FENvn59tMZW6mOVfpq9mGxGf8l6+EGaXUOd4RBOLg7tRC83OrirM5AtDvZRpdjdlXURsHreAOSPOUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -27252,7 +27268,7 @@
     },
     "packages/components": {
       "name": "@altersend/components",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"
@@ -27421,7 +27437,7 @@
     },
     "packages/core": {
       "name": "@altersend/core",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.8.0",
@@ -27452,10 +27468,10 @@
     },
     "packages/domain": {
       "name": "@altersend/domain",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@altersend/core": "1.0.0"
+        "@altersend/core": "1.1.0"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^3.0.0",
     "typescript-eslint": "^8.59.2"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "dependencies": {
     "expo": "~55.0.15",
     "react": "19.2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altersend/components",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "description": "Shared AlterSend UI theme and React Strict DOM setup",

--- a/packages/components/src/icons/set.tsx
+++ b/packages/components/src/icons/set.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpRight,
   AppWindow,
   Bell,
+  Camera,
   Check,
   ChevronDown,
   ChevronRight,
@@ -43,6 +44,7 @@ export const ArrowLeftIcon = adaptLucide(ArrowLeft)
 export const ArrowUpRightIcon = adaptLucide(ArrowUpRight)
 export const AppWindowIcon = adaptLucide(AppWindow)
 export const BellIcon = adaptLucide(Bell)
+export const CameraIcon = adaptLucide(Camera)
 export const CheckIcon = adaptLucide(Check)
 export const ChevronDownIcon = adaptLucide(ChevronDown)
 export const ChevronRightIcon = adaptLucide(ChevronRight)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altersend/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altersend/domain",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@altersend/core": "1.0.0"
+    "@altersend/core": "1.1.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary

Adds webcam QR-code scanning to the desktop Receive flow, fixes two mobile bugs (Settings button on Android, send flow stuck at 100%), and bumps the workspace to v1.1.0.
