### PR TITLE
Added update banner for desktop/mobile

### DIFF
--- a/apps/desktop/src/electron/preload.cjs
+++ b/apps/desktop/src/electron/preload.cjs
@@ -16,7 +16,6 @@ contextBridge.exposeInMainWorld('bridge', {
     return () => ipcRenderer.removeListener('pear:worker:event:' + P2P_WORKER, listener)
   },
 
-  applyUpdate: () => ipcRenderer.invoke('pear:applyUpdate'),
   pickFiles: () => ipcRenderer.invoke('app:pickFiles'),
   pickDirectory: () => ipcRenderer.invoke('app:pickDirectory'),
   pickSaveFile: (defaultName) => {
@@ -42,6 +41,11 @@ contextBridge.exposeInMainWorld('bridge', {
     const listener = (_evt, url) => cb(url)
     ipcRenderer.on('app:deep-link', listener)
     return () => ipcRenderer.removeListener('app:deep-link', listener)
+  },
+  onRuntimeUpdated: (cb) => {
+    const listener = () => cb()
+    ipcRenderer.on('runtime:updated', listener)
+    return () => ipcRenderer.removeListener('runtime:updated', listener)
   },
   setSentryEnabled: (enabled) => ipcRenderer.invoke('sentry:setEnabled', enabled),
   requestCameraAccess: () => ipcRenderer.invoke('app:requestCameraAccess'),

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -3,11 +3,13 @@ import { useSimulatedLoading } from '@altersend/domain'
 import { bridgeApi, hasBridge } from './api/bridgeApi'
 import { UpdateBanner } from './components/UpdateBanner'
 import { isOnboardingCompleted, markOnboardingCompleted } from './lifecycle/onboardingStorage'
+import { useUpdateReady } from './lifecycle/useUpdateReady'
 import { BridgeUnavailablePage, LoadingPage, OnboardingPage, TransferPage } from './pages'
 
 export default function App() {
   const [showOnboarding, setShowOnboarding] = useState(() => !isOnboardingCompleted())
   const progress = useSimulatedLoading()
+  const updateReady = useUpdateReady()
 
   if (progress < 100) {
     return <LoadingPage progress={progress} />
@@ -21,19 +23,22 @@ export default function App() {
 
   if (showOnboarding) {
     return (
-      <OnboardingPage
-        onFinish={() => {
-          markOnboardingCompleted()
-          setShowOnboarding(false)
-        }}
-      />
+      <>
+        <OnboardingPage
+          onFinish={() => {
+            markOnboardingCompleted()
+            setShowOnboarding(false)
+          }}
+        />
+        <UpdateBanner ready={updateReady} />
+      </>
     )
   }
 
   return (
     <>
       <TransferPage version={version} />
-      <UpdateBanner />
+      <UpdateBanner ready={updateReady} />
     </>
   )
 }

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useSimulatedLoading } from '@altersend/domain'
 import { bridgeApi, hasBridge } from './api/bridgeApi'
+import { UpdateBanner } from './components/UpdateBanner'
 import { isOnboardingCompleted, markOnboardingCompleted } from './lifecycle/onboardingStorage'
 import { BridgeUnavailablePage, LoadingPage, OnboardingPage, TransferPage } from './pages'
 
@@ -29,5 +30,10 @@ export default function App() {
     )
   }
 
-  return <TransferPage version={version} />
+  return (
+    <>
+      <TransferPage version={version} />
+      <UpdateBanner />
+    </>
+  )
 }

--- a/apps/desktop/src/renderer/api/bridgeApi.ts
+++ b/apps/desktop/src/renderer/api/bridgeApi.ts
@@ -43,9 +43,6 @@ export const bridgeApi = {
   onTransferEvent(cb: (message: RendererTransferEvent) => void) {
     return requireBridge().onTransferEvent(cb)
   },
-  applyUpdate() {
-    return requireBridge().applyUpdate()
-  },
   pickFiles() {
     return requireBridge().pickFiles()
   },
@@ -72,6 +69,9 @@ export const bridgeApi = {
   },
   onDeepLink(cb: (url: string) => void) {
     return requireBridge().onDeepLink(cb)
+  },
+  onRuntimeUpdated(cb: () => void) {
+    return requireBridge().onRuntimeUpdated(cb)
   },
   setSentryEnabled(enabled: boolean) {
     return requireBridge().setSentryEnabled(enabled)

--- a/apps/desktop/src/renderer/components/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/UpdateBanner.tsx
@@ -1,0 +1,39 @@
+import { ArrowUp, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { bridgeApi } from '../api/bridgeApi'
+
+export function UpdateBanner() {
+  const [ready, setReady] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    return bridgeApi.onRuntimeUpdated(() => setReady(true))
+  }, [])
+
+  if (!ready || dismissed) return null
+
+  return (
+    <div className='pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center px-4'>
+      <div className='pointer-events-auto flex items-center gap-2.5 rounded-full border border-border-primary bg-surface-secondary px-5 py-2.5 shadow-lg min-w-[260px]'>
+        <div className='flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full bg-info/15'>
+          <ArrowUp size={12} className='text-info' />
+        </div>
+        <span className='flex-1 text-[13px] font-semibold text-text-primary'>Update ready</span>
+        <div className='flex items-center gap-2'>
+          <button
+            onClick={() => void bridgeApi.appRestart()}
+            className='appearance-none border-0 bg-transparent p-0 text-[13px] font-semibold text-info cursor-pointer'
+          >
+            Restart
+          </button>
+          <button
+            onClick={() => setDismissed(true)}
+            className='flex appearance-none border-0 bg-transparent p-0 cursor-pointer text-text-secondary'
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/UpdateBanner.tsx
@@ -1,36 +1,45 @@
 import { ArrowUp, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { bridgeApi } from '../api/bridgeApi'
 
-export function UpdateBanner() {
-  const [ready, setReady] = useState(false)
+export function UpdateBanner({ ready }: { ready: boolean }) {
   const [dismissed, setDismissed] = useState(false)
-
-  useEffect(() => {
-    return bridgeApi.onRuntimeUpdated(() => setReady(true))
-  }, [])
+  const [restartFailed, setRestartFailed] = useState(false)
 
   if (!ready || dismissed) return null
+
+  const restart = async () => {
+    setRestartFailed(false)
+    try {
+      await bridgeApi.appRestart()
+    } catch (err) {
+      console.error('Failed to restart for update', err)
+      setRestartFailed(true)
+    }
+  }
 
   return (
     <div className='pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center px-4'>
       <div className='pointer-events-auto flex items-center gap-2.5 rounded-full border border-border-primary bg-surface-secondary px-5 py-2.5 shadow-lg min-w-[260px]'>
         <div className='flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full bg-info/15'>
-          <ArrowUp size={12} className='text-info' />
+          <ArrowUp size={12} className='text-info' aria-hidden />
         </div>
-        <span className='flex-1 text-[13px] font-semibold text-text-primary'>Update ready</span>
+        <span className='flex-1 text-[13px] font-semibold text-text-primary'>
+          {restartFailed ? 'Restart failed — please quit and reopen' : 'Update ready'}
+        </span>
         <div className='flex items-center gap-2'>
           <button
-            onClick={() => void bridgeApi.appRestart()}
+            onClick={() => void restart()}
             className='appearance-none border-0 bg-transparent p-0 text-[13px] font-semibold text-info cursor-pointer'
           >
             Restart
           </button>
           <button
+            aria-label='Dismiss'
             onClick={() => setDismissed(true)}
             className='flex appearance-none border-0 bg-transparent p-0 cursor-pointer text-text-secondary'
           >
-            <X size={14} />
+            <X size={14} aria-hidden />
           </button>
         </div>
       </div>

--- a/apps/desktop/src/renderer/lifecycle/useUpdateReady.ts
+++ b/apps/desktop/src/renderer/lifecycle/useUpdateReady.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+import { bridgeApi, hasBridge } from '../api/bridgeApi'
+
+// runtime:updated is a one-shot broadcast, so register on app mount — not when
+// the banner mounts — to avoid missing it during onboarding or loading.
+export function useUpdateReady() {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    if (!hasBridge()) return
+    return bridgeApi.onRuntimeUpdated(() => setReady(true))
+  }, [])
+
+  return ready
+}

--- a/apps/desktop/src/types.d.ts
+++ b/apps/desktop/src/types.d.ts
@@ -61,13 +61,13 @@ declare global {
       ...args: TransferMethodArgs<T>
     ) => TransferMethodReturn<T>
     onTransferEvent: (cb: (message: RendererTransferEvent) => void) => () => void
-    applyUpdate: () => Promise<unknown>
     pickFiles: () => Promise<PickedFile[] | null>
     pickDirectory: () => Promise<PickedFile | null>
     pickSaveFile: (defaultName: string) => Promise<PickedFile | null>
     getPathForFile: (file: File) => string
     appRestart: () => Promise<unknown>
     onDeepLink: (cb: (url: string) => void) => () => void
+    onRuntimeUpdated: (cb: () => void) => () => void
     showInFolder: (filePath: string) => Promise<void>
     openFile: (filePath: string) => Promise<string>
     openExternalUrl: (url: string) => Promise<void>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -18,6 +18,7 @@ import { LoadingScreen } from '../src/loading'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { mobileApi } from '../src/api/mobileApi'
 import { ToastProvider } from '../src/components/Toast'
+import { UpdateBanner } from '../src/components/UpdateBanner'
 import { startAppStateBridge } from '../src/lifecycle/appStateBridge'
 import { startDeepLinkHandler } from '../src/lifecycle/deepLinkHandler'
 import { ShareIntentHandler } from '../src/lifecycle/ShareIntentHandler'
@@ -102,6 +103,7 @@ export default function RootLayout() {
             <ToastProvider>
               <ShareIntentHandler />
               <ThemedStack />
+              <UpdateBanner />
             </ToastProvider>
           </ErrorBoundary>
         </ThemeProvider>

--- a/apps/mobile/src/components/UpdateBanner/index.tsx
+++ b/apps/mobile/src/components/UpdateBanner/index.tsx
@@ -1,0 +1,102 @@
+import { useTheme } from '@altersend/components'
+import { ArrowUp, X } from 'lucide-react-native'
+import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useUpdateCheck } from '../../hooks/useUpdateCheck'
+
+const STORE_URL =
+  Platform.OS === 'ios'
+    ? 'https://apps.apple.com/us/app/altersend-file-transfer/id6772496271'
+    : 'https://play.google.com/store/apps/details?id=com.altersend.mobile'
+
+export function UpdateBanner() {
+  const { theme } = useTheme()
+  const insets = useSafeAreaInsets()
+  const { needsUpdate, dismiss } = useUpdateCheck()
+
+  if (!needsUpdate) return null
+
+  return (
+    <View
+      pointerEvents='box-none'
+      style={[styles.container, { top: insets.top + 16 }]}
+    >
+      <View
+        style={[
+          styles.banner,
+          {
+            backgroundColor: theme.colors.colorSurfaceSecondary,
+            borderColor: theme.colors.colorBorderPrimary,
+            shadowColor: theme.colors.colorScrim,
+          },
+        ]}
+      >
+        <View
+          style={[
+            styles.iconWrap,
+            { backgroundColor: theme.colors.colorInfoSubtle },
+          ]}
+        >
+          <ArrowUp size={14} color={theme.colors.colorInfo} />
+        </View>
+
+        <Text
+          style={[styles.label, { color: theme.colors.colorTextPrimary }]}
+          numberOfLines={1}
+        >
+          Update available
+        </Text>
+
+        <Pressable
+          onPress={() => { dismiss(); void Linking.openURL(STORE_URL).catch(() => {}) }}
+          hitSlop={8}
+        >
+          <Text style={[styles.updateBtn, { color: theme.colors.colorInfo }]}>
+            Update
+          </Text>
+        </Pressable>
+
+        <Pressable onPress={dismiss} hitSlop={8}>
+          <X size={16} color={theme.colors.colorTextSecondary} />
+        </Pressable>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    borderWidth: 1,
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.18,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  iconWrap: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  updateBtn: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/src/components/UpdateBanner/index.tsx
+++ b/apps/mobile/src/components/UpdateBanner/index.tsx
@@ -17,43 +17,33 @@ export function UpdateBanner() {
   if (!needsUpdate) return null
 
   return (
-    <View
-      pointerEvents='box-none'
-      style={[styles.container, { top: insets.top + 16 }]}
-    >
+    <View pointerEvents='box-none' style={[styles.container, { top: insets.top + 16 }]}>
       <View
         style={[
           styles.banner,
           {
             backgroundColor: theme.colors.colorSurfaceSecondary,
             borderColor: theme.colors.colorBorderPrimary,
-            shadowColor: theme.colors.colorScrim,
-          },
+            shadowColor: theme.colors.colorScrim
+          }
         ]}
       >
-        <View
-          style={[
-            styles.iconWrap,
-            { backgroundColor: theme.colors.colorInfoSubtle },
-          ]}
-        >
+        <View style={[styles.iconWrap, { backgroundColor: theme.colors.colorInfoSubtle }]}>
           <ArrowUp size={14} color={theme.colors.colorInfo} />
         </View>
 
-        <Text
-          style={[styles.label, { color: theme.colors.colorTextPrimary }]}
-          numberOfLines={1}
-        >
+        <Text style={[styles.label, { color: theme.colors.colorTextPrimary }]} numberOfLines={1}>
           Update available
         </Text>
 
         <Pressable
-          onPress={() => { dismiss(); void Linking.openURL(STORE_URL).catch(() => {}) }}
+          onPress={() => {
+            dismiss()
+            void Linking.openURL(STORE_URL).catch(() => {})
+          }}
           hitSlop={8}
         >
-          <Text style={[styles.updateBtn, { color: theme.colors.colorInfo }]}>
-            Update
-          </Text>
+          <Text style={[styles.updateBtn, { color: theme.colors.colorInfo }]}>Update</Text>
         </Pressable>
 
         <Pressable onPress={dismiss} hitSlop={8}>
@@ -68,7 +58,7 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     left: 16,
-    right: 16,
+    right: 16
   },
   banner: {
     flexDirection: 'row',
@@ -81,22 +71,22 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 6 },
     shadowOpacity: 0.18,
     shadowRadius: 16,
-    elevation: 8,
+    elevation: 8
   },
   iconWrap: {
     width: 22,
     height: 22,
     borderRadius: 11,
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'center'
   },
   label: {
     flex: 1,
     fontSize: 14,
-    fontWeight: '600',
+    fontWeight: '600'
   },
   updateBtn: {
     fontSize: 14,
-    fontWeight: '600',
-  },
+    fontWeight: '600'
+  }
 })

--- a/apps/mobile/src/hooks/useUpdateCheck.ts
+++ b/apps/mobile/src/hooks/useUpdateCheck.ts
@@ -6,8 +6,7 @@ const CACHE_DIR = 'altersend'
 const CACHE_FILE = 'update-check.json'
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 10_000
-const GITHUB_RELEASES_URL =
-  'https://api.github.com/repos/denislupookov/altersend/releases/latest'
+const GITHUB_RELEASES_URL = 'https://api.github.com/repos/denislupookov/altersend/releases/latest'
 
 interface CacheEntry {
   version: string
@@ -16,7 +15,10 @@ interface CacheEntry {
 }
 
 function parseParts(version: string): number[] {
-  return version.replace(/[^0-9.]/g, '').split('.').map(Number)
+  return version
+    .replace(/[^0-9.]/g, '')
+    .split('.')
+    .map(Number)
 }
 
 function isNewer(current: string, latest: string): boolean {
@@ -67,7 +69,7 @@ async function fetchLatestRelease(): Promise<CacheEntry | null> {
   try {
     const res = await fetch(GITHUB_RELEASES_URL, {
       headers: { 'User-Agent': 'AlterSend' },
-      signal: controller.signal,
+      signal: controller.signal
     })
     if (!res.ok) return null
 

--- a/apps/mobile/src/hooks/useUpdateCheck.ts
+++ b/apps/mobile/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,134 @@
+import Constants from 'expo-constants'
+import { Directory, File, Paths } from 'expo-file-system'
+import { useCallback, useEffect, useState } from 'react'
+
+const CACHE_DIR = 'altersend'
+const CACHE_FILE = 'update-check.json'
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const FETCH_TIMEOUT_MS = 10_000
+const GITHUB_RELEASES_URL =
+  'https://api.github.com/repos/denislupookov/altersend/releases/latest'
+
+interface CacheEntry {
+  version: string
+  fetchedAt: number
+  dismissedVersion?: string
+}
+
+function parseParts(version: string): number[] {
+  return version.replace(/[^0-9.]/g, '').split('.').map(Number)
+}
+
+function isNewer(current: string, latest: string): boolean {
+  const cur = parseParts(current)
+  const lat = parseParts(latest)
+  for (let i = 0; i < Math.max(cur.length, lat.length); i++) {
+    if ((lat[i] ?? 0) > (cur[i] ?? 0)) return true
+    if ((lat[i] ?? 0) < (cur[i] ?? 0)) return false
+  }
+  return false
+}
+
+function getCacheFile(): File | null {
+  const base = Paths.document
+  if (!base?.uri) return null
+  return new File(new Directory(base, CACHE_DIR), CACHE_FILE)
+}
+
+function isCacheStale(entry: CacheEntry): boolean {
+  return Date.now() - entry.fetchedAt > CACHE_TTL_MS
+}
+
+function readCache(): CacheEntry | null {
+  try {
+    const file = getCacheFile()
+    if (!file?.exists) return null
+    const data = JSON.parse(file.textSync())
+    if (typeof data.version === 'string' && typeof data.fetchedAt === 'number') return data
+    return null
+  } catch {
+    return null
+  }
+}
+
+function writeCache(entry: CacheEntry): void {
+  try {
+    const base = Paths.document
+    if (!base?.uri) return
+    const dir = new Directory(base, CACHE_DIR)
+    if (!dir.exists) dir.create({ idempotent: true, intermediates: true })
+    new File(dir, CACHE_FILE).write(JSON.stringify(entry))
+  } catch {}
+}
+
+async function fetchLatestRelease(): Promise<CacheEntry | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const res = await fetch(GITHUB_RELEASES_URL, {
+      headers: { 'User-Agent': 'AlterSend' },
+      signal: controller.signal,
+    })
+    if (!res.ok) return null
+
+    const json = await res.json()
+    const isStableRelease = !json.draft && !json.prerelease
+    const tag: string = json.tag_name ?? ''
+    const isValidTag = /^v?\d+\.\d+/.test(tag)
+
+    if (!isStableRelease || !isValidTag) return null
+
+    return { version: tag.replace(/^v/, ''), fetchedAt: Date.now() }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export function useUpdateCheck(): { needsUpdate: boolean; dismiss: () => void } {
+  const [entry, setEntry] = useState<CacheEntry | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function check() {
+      const current = Constants.expoConfig?.version
+      if (!current) return
+
+      let cached = readCache()
+      if (!cached || isCacheStale(cached)) {
+        const fetched = await fetchLatestRelease()
+        if (fetched) {
+          const next = { ...fetched, dismissedVersion: cached?.dismissedVersion }
+          writeCache(next)
+          cached = next
+        }
+      }
+
+      if (!cancelled && cached) setEntry(cached)
+    }
+
+    const timer = setTimeout(check, 1000)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [])
+
+  const dismiss = useCallback(() => {
+    if (!entry) return
+    const updated = { ...entry, dismissedVersion: entry.version }
+    writeCache(updated)
+    setEntry(updated)
+  }, [entry])
+
+  const current = Constants.expoConfig?.version ?? ''
+  const needsUpdate =
+    !!current &&
+    !!entry &&
+    entry.dismissedVersion !== entry.version &&
+    isNewer(current, entry.version)
+
+  return { needsUpdate, dismiss }
+}


### PR DESCRIPTION
Added update banner for desktop/mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop: global update banner appears when a runtime update is ready (shown across onboarding and main flows), offering Restart and Dismiss actions and showing a restart-failed message if restart fails.
  * Mobile: periodic update check shows a top banner linking to the App Store or Play Store with a Dismiss action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->