### PR TITLE
fix: resolve hanging transfers from Android to Windows

### DIFF
--- a/apps/mobile/src/transfer/send/views/SelectFilesView.tsx
+++ b/apps/mobile/src/transfer/send/views/SelectFilesView.tsx
@@ -39,7 +39,8 @@ export function SelectFilesView() {
       const normalizedFiles: SelectedFile[] = result.assets.map((asset) => ({
         name: asset.name,
         path: uriToFilePath(asset.uri),
-        size: asset.size
+        size: asset.size,
+        isTemporary: true
       }))
 
       if (normalizedFiles.length > 0) {
@@ -66,7 +67,8 @@ export function SelectFilesView() {
       const normalizedFiles: SelectedFile[] = result.assets.map((asset) => ({
         name: asset.fileName ?? asset.uri.split('/').pop() ?? 'photo',
         path: uriToFilePath(asset.uri),
-        size: asset.fileSize
+        size: asset.fileSize,
+        isTemporary: true
       }))
 
       if (normalizedFiles.length > 0) {

--- a/apps/mobile/src/transfer/send/views/SelectFilesView.tsx
+++ b/apps/mobile/src/transfer/send/views/SelectFilesView.tsx
@@ -31,7 +31,7 @@ export function SelectFilesView() {
       const result = await DocumentPicker.getDocumentAsync({
         multiple: true,
         type: '*/*',
-        copyToCacheDirectory: false
+        copyToCacheDirectory: true
       })
 
       if (result.canceled) return

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,8 @@ export type {
   DownloadFilesReply,
   DisconnectReply,
   DownloadFileRequest,
-  DownloadFileResult
+  DownloadFileResult,
+  ShareFileRequest
 } from './worklet/rpc/protocol'
 
 export type { TransferStatus } from './worklet/rpc/events'

--- a/packages/core/src/worklet/rpc/protocol.ts
+++ b/packages/core/src/worklet/rpc/protocol.ts
@@ -26,6 +26,11 @@ export interface JoinReply {
   state: 'joined'
 }
 
+export interface ShareFileRequest {
+  path: string
+  isTemporary?: boolean
+}
+
 export interface ShareFilesReply {
   acceptedFiles: number
 }
@@ -71,7 +76,7 @@ export type IncomingFileOffer = FileOffer
 export interface TransferRPC {
   host(): Promise<HostReply>
   join(topic: string): Promise<JoinReply>
-  shareFiles(paths: string[]): Promise<ShareFilesReply>
+  shareFiles(files: ShareFileRequest[]): Promise<ShareFilesReply>
   downloadFiles(files: DownloadFileRequest[]): Promise<DownloadFilesReply>
   disconnect(): Promise<DisconnectReply>
   closePeers(): Promise<void>

--- a/packages/core/src/worklet/transfer/orchestrator.ts
+++ b/packages/core/src/worklet/transfer/orchestrator.ts
@@ -18,6 +18,7 @@ import type {
   DownloadFilesReply,
   HostReply,
   JoinReply,
+  ShareFileRequest,
   ShareFilesReply,
   TransferRPC
 } from '../rpc/protocol'
@@ -293,8 +294,8 @@ export class TransferOrchestrator implements TransferRPC {
     return { state: 'joined' }
   }
 
-  async shareFiles(paths: string[]): Promise<ShareFilesReply> {
-    if (!Array.isArray(paths) || paths.length === 0) {
+  async shareFiles(requests: ShareFileRequest[]): Promise<ShareFilesReply> {
+    if (!Array.isArray(requests) || requests.length === 0) {
       throw new BadRequestError('Missing files to share')
     }
     if (this.suspended) {
@@ -308,7 +309,7 @@ export class TransferOrchestrator implements TransferRPC {
     await this.readyPromise
 
     try {
-      const { files, totalBytes, errors } = await this.stager.scanFiles(paths)
+      const { files, totalBytes, errors } = await this.stager.scanFiles(requests)
       for (const error of errors) this.sendError(error)
 
       if (files.length === 0) {

--- a/packages/core/src/worklet/transfer/sender.ts
+++ b/packages/core/src/worklet/transfer/sender.ts
@@ -1,4 +1,5 @@
 import crypto from 'hypercore-crypto'
+import fs from 'bare-fs'
 import b4a from 'b4a'
 import Localdrive from 'localdrive'
 import MirrorDrive from 'mirror-drive'
@@ -105,6 +106,7 @@ export class TransferSender {
       if (signal?.aborted) throw new AbortError()
       onStaging(file)
       await this.importToDrive(file.sourceDrive, file.sourcePath)
+      await this.tryDeleteIfInCache(file.inputPath)
       offers.push({
         id: createFileId(),
         transferId,
@@ -124,5 +126,16 @@ export class TransferSender {
       prune: false
     })
     await mirror.done()
+  }
+
+  private async tryDeleteIfInCache(filePath: string): Promise<void> {
+    // Only target Expo DocumentPicker or ImagePicker cache directories to prevent accidental data loss
+    const isExpoCache = /\/(cache|Caches)\/(DocumentPicker|ImagePicker)\//i.test(filePath)
+    if (!isExpoCache) return
+    try {
+      await fs.promises.unlink(filePath)
+    } catch (err) {
+      console.warn(`TransferSender: failed to delete cached file ${filePath}`, err)
+    }
   }
 }

--- a/packages/core/src/worklet/transfer/sender.ts
+++ b/packages/core/src/worklet/transfer/sender.ts
@@ -13,6 +13,8 @@ export interface ScannedFile {
   sourcePath: string
   sourceDrive: Localdrive
   size: number
+  isTemporary?: boolean
+  alreadyStaged?: boolean
 }
 
 export interface ScanResult {
@@ -48,14 +50,15 @@ export class TransferSender {
     return b4a.toString(this.drive.key, 'hex')
   }
 
-  async scanFiles(paths: string[]): Promise<ScanResult> {
+  async scanFiles(requests: { path: string; isTemporary?: boolean }[]): Promise<ScanResult> {
     const files: ScannedFile[] = []
     const errors: string[] = []
     let totalBytes = 0
 
     const driveByDir = new Map<string, Localdrive>()
 
-    for (const path of paths) {
+    for (const req of requests) {
+      const path = req.path
       const fileName = getFileName(path)
       const sourcePath = `/${fileName}`
       const dir = getDirname(path)
@@ -69,13 +72,35 @@ export class TransferSender {
       const entry = await sourceDrive.entry(sourcePath)
 
       if (!entry?.value?.blob) {
+        const existingEntry = await this.drive.entry(sourcePath)
+        if (existingEntry?.value?.blob) {
+          const size = existingEntry.value.blob.byteLength
+          totalBytes += size
+          files.push({
+            fileName,
+            inputPath: path,
+            sourcePath,
+            sourceDrive,
+            size,
+            isTemporary: req.isTemporary,
+            alreadyStaged: true
+          })
+          continue
+        }
         errors.push(`Could not read file: ${fileName}`)
         continue
       }
 
       const size = entry.value.blob.byteLength
       totalBytes += size
-      files.push({ fileName, inputPath: path, sourcePath, sourceDrive, size })
+      files.push({
+        fileName,
+        inputPath: path,
+        sourcePath,
+        sourceDrive,
+        size,
+        isTemporary: req.isTemporary
+      })
     }
 
     return { files, totalBytes, errors }
@@ -105,8 +130,12 @@ export class TransferSender {
       // Per-file granularity — MirrorDrive in flight is not abortable.
       if (signal?.aborted) throw new AbortError()
       onStaging(file)
-      await this.importToDrive(file.sourceDrive, file.sourcePath)
-      await this.tryDeleteIfInCache(file.inputPath)
+      if (!file.alreadyStaged) {
+        await this.importToDrive(file.sourceDrive, file.sourcePath)
+        if (file.isTemporary) {
+          await this.tryDeleteFile(file.inputPath)
+        }
+      }
       offers.push({
         id: createFileId(),
         transferId,
@@ -128,14 +157,11 @@ export class TransferSender {
     await mirror.done()
   }
 
-  private async tryDeleteIfInCache(filePath: string): Promise<void> {
-    // Only target Expo DocumentPicker or ImagePicker cache directories to prevent accidental data loss
-    const isExpoCache = /\/(cache|Caches)\/(DocumentPicker|ImagePicker)\//i.test(filePath)
-    if (!isExpoCache) return
+  private async tryDeleteFile(filePath: string): Promise<void> {
     try {
       await fs.promises.unlink(filePath)
     } catch (err) {
-      console.warn(`TransferSender: failed to delete cached file ${filePath}`, err)
+      console.warn(`TransferSender: failed to delete temporary file ${filePath}`, err)
     }
   }
 }

--- a/packages/domain/src/send/draftTypes.ts
+++ b/packages/domain/src/send/draftTypes.ts
@@ -2,6 +2,7 @@ export interface SelectedFile {
   name: string
   path: string
   size?: number
+  isTemporary?: boolean
 }
 
 export type SenderUploadStatus = 'waiting' | 'uploading' | 'completed'

--- a/packages/domain/src/transfer/commands.ts
+++ b/packages/domain/src/transfer/commands.ts
@@ -6,6 +6,7 @@ import type {
   DownloadFileRequest,
   DownloadFilesReply,
   JoinReply,
+  ShareFileRequest,
   ShareFilesReply
 } from '@altersend/core'
 
@@ -48,10 +49,10 @@ export const joinSession = async (topic: string): Promise<JoinReply> => {
   }
 }
 
-export const shareFiles = async (paths: string[]): Promise<ShareFilesReply> => {
+export const shareFiles = async (files: ShareFileRequest[]): Promise<ShareFilesReply> => {
   dispatchToTransferStore({ type: 'share_requested' })
   try {
-    return await getTransferApi().worker.shareFiles(paths)
+    return await getTransferApi().worker.shareFiles(files)
   } catch (error) {
     reportError('shareFiles', error)
     dispatchToTransferStore({ type: 'role_changed', role: null })
@@ -99,7 +100,10 @@ export const clearSenderFlow = (): void => {
 export const continueShare = async (files: SelectedFile[]): Promise<void> => {
   if (files.length === 0) return
 
-  const filePaths = files.map((file) => file.path)
+  const fileRequests: ShareFileRequest[] = files.map((file) => ({
+    path: file.path,
+    isTemporary: file.isTemporary
+  }))
   dispatchToTransferStore({
     type: 'init_upload_items',
     items: createInitialUploadItems(files)
@@ -108,7 +112,7 @@ export const continueShare = async (files: SelectedFile[]): Promise<void> => {
 
   try {
     await startSendSession()
-    await shareFiles(filePaths)
+    await shareFiles(fileRequests)
     dispatchToTransferStore({ type: 'complete_all_uploads' })
     dispatchToTransferStore({ type: 'set_draft_phase', phase: 'ready' })
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes a critical issue where Android sender transfers would hang indefinitely during the handshake phase (Issue #2) when files are selected through the Android Storage Access Framework (SAF).

The previous implementation used `copyToCacheDirectory: false`, which caused Expo to return `content://` URIs instead of native file paths. Since the Node.js transfer worker cannot directly consume Android content providers, file scanning would silently fail, producing an empty transfer payload and leaving the receiver stuck waiting for data.

This PR fixes the Android transfer hang, reduces the additional disk usage introduced by cache materialization, and improves the transfer lifecycle to safely handle cancellations and retries.

---

## Changes

### 1. Android SAF compatibility

To work around the `content://` URI limitation, the Android document picker flow now uses:

```ts
copyToCacheDirectory: true
```

This forces Expo to materialize the selected SAF asset into the app's private cache directory, giving the Node.js `Localdrive` worker a real file path that can be read normally.

---

### 2. Disk usage optimization

A side effect of enabling cache copies is increased temporary disk usage.

For example, during a 4 GB transfer the peak footprint would otherwise reach around 12 GB:

```
Original file:        4 GB
Expo cache copy:      4 GB
Hyperdrive storage:   4 GB
--------------------------
Peak total:          12 GB
```

To keep peak usage closer to ~8 GB, `TransferSender` now removes temporary cache files using `fs.promises.unlink` after they have been successfully mirrored into Hyperdrive.

---

### 3. Explicit temporary file handling

The first cleanup implementation detected removable files using an Expo-specific path heuristic:

```ts
/\/(cache|Caches)\/(DocumentPicker|ImagePicker)\//i
```

This worked, but leaked frontend framework assumptions into the transfer backend.

The cleanup flow now uses an explicit ownership signal:

* `SelectFilesView.tsx` marks picker files with `isTemporary: true`
* `TransferRPC.shareFiles` now receives `ShareFileRequest[]` instead of `string[]`
* the worker only deletes files explicitly marked as temporary

This keeps the transfer domain independent from Expo-specific behavior.

---

### 4. Retry and cancellation recovery

Deleting cache files aggressively introduced an important edge case:

If a transfer was canceled mid-way through an `AbortSignal`, or if the network failed and the user retried, the frontend could still contain stale cache paths inside `selectedFiles`.

A second `scanFiles` call would then attempt to read a file that had already been deleted.

To fix this, `TransferSender.scanFiles` now includes a Hyperdrive recovery path:

1. Attempt to read from `Localdrive`
2. If the file no longer exists, check `this.drive.entry`
3. If the file was already staged, mark it as `alreadyStaged: true`
4. `stageFiles` skips both MirrorDrive ingestion and cache deletion for already staged files

This allows retries to resume cleanly instead of invalidating the transfer state.

---

## Notes

### Zero-copy readiness

This PR works as a compatibility layer for the current transfer architecture.

A future zero-copy implementation can avoid cache materialization entirely by exposing Android SAF files through a native stream or file descriptor bridge.

Because cleanup ownership is now represented through the `isTemporary` flag, the migration path should not require changes to the core transfer lifecycle:

* cached picker files → `isTemporary: true`
* native zero-copy streams → no temporary ownership flag

---

### Pre-existing namespace collision issue

While reviewing the `TransferSender` execution flow, I found an unrelated pre-existing issue in how files are mapped into Hyperdrive.

Currently, destination paths are flattened into the root namespace:

```ts
const fileName = getFileName(path)
const sourcePath = `/${fileName}`
```

This means two different files with the same name can collide:

```
/Downloads/invoice.pdf
/Documents/invoice.pdf
```

Both become:

```
/invoice.pdf
```

The second file can overwrite the first one inside MirrorDrive, causing validation failures when the receiver downloads the overwritten entry.

This should be addressed in a follow-up PR before folder uploads or large batch selections are supported.

Possible solutions:

* preserve the original relative directory structure
* prefix files with a stable unique identifier (`/${fileId}/${fileName}`)

---

## 🔗 Related issues

Resolves #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Files selected from your device are now automatically cleaned up after transfer completion.
  * Files already present at your destination are no longer re-imported, reducing transfer time and improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->