### PR TITLE
Save received documents to Android Downloads via MediaStore

### DIFF
--- a/apps/mobile/modules/media-store/android/build.gradle
+++ b/apps/mobile/modules/media-store/android/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules'
+version = '1.0.0'
+
+android {
+  namespace "expo.modules.mediastore"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+}

--- a/apps/mobile/modules/media-store/android/src/main/java/expo/modules/mediastore/MediaStoreModule.kt
+++ b/apps/mobile/modules/media-store/android/src/main/java/expo/modules/mediastore/MediaStoreModule.kt
@@ -1,0 +1,86 @@
+package expo.modules.mediastore
+
+import android.content.ContentValues
+import android.content.Intent
+import android.net.Uri
+import android.os.Environment
+import android.provider.MediaStore
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.io.File
+
+private const val COPY_BUFFER_SIZE = 1024 * 1024
+
+class MediaStoreModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("MediaStore")
+
+    // Streams a private file into the public Downloads collection and deletes the source.
+    AsyncFunction("saveToDownloads") { srcPath: String, fileName: String, mimeType: String ->
+      val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+      val resolver = context.contentResolver
+
+      val srcFilePath = if (srcPath.startsWith("file://")) Uri.parse(srcPath).path ?: srcPath else srcPath
+      val src = File(srcFilePath)
+      if (!src.exists()) throw IllegalArgumentException("Source file does not exist: $srcPath")
+
+      val pending = ContentValues().apply {
+        put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+        if (mimeType.isNotEmpty()) put(MediaStore.Downloads.MIME_TYPE, mimeType)
+        put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+        put(MediaStore.Downloads.IS_PENDING, 1)
+      }
+
+      val collection = MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+      val itemUri = resolver.insert(collection, pending)
+        ?: throw IllegalStateException("Failed to create Downloads entry for $fileName")
+
+      try {
+        resolver.openOutputStream(itemUri).use { output ->
+          output ?: throw IllegalStateException("Failed to open Downloads output stream")
+          src.inputStream().use { input -> input.copyTo(output, COPY_BUFFER_SIZE) }
+        }
+      } catch (e: Exception) {
+        resolver.delete(itemUri, null, null)
+        throw e
+      }
+
+      val finalized = resolver.update(
+        itemUri,
+        ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) },
+        null,
+        null
+      )
+      if (finalized == 0) {
+        resolver.delete(itemUri, null, null)
+        throw IllegalStateException("Failed to finalize Downloads entry for $fileName")
+      }
+      src.delete()
+
+      itemUri.toString()
+    }
+
+    // Opens a saved Downloads item in an external viewer via ACTION_VIEW.
+    AsyncFunction("openDownload") { contentUri: String, mimeType: String ->
+      val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+      val intent = Intent(Intent.ACTION_VIEW).apply {
+        setDataAndType(Uri.parse(contentUri), mimeType.ifEmpty { "*/*" })
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      }
+      context.startActivity(Intent.createChooser(intent, null).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      })
+    }
+
+    // Opens the system Downloads UI.
+    AsyncFunction("openDownloadsFolder") {
+      val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+      val intent = Intent(android.app.DownloadManager.ACTION_VIEW_DOWNLOADS).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      }
+      context.startActivity(intent)
+    }
+  }
+}

--- a/apps/mobile/modules/media-store/expo-module.config.json
+++ b/apps/mobile/modules/media-store/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.mediastore.MediaStoreModule"]
+  }
+}

--- a/apps/mobile/modules/media-store/index.ts
+++ b/apps/mobile/modules/media-store/index.ts
@@ -1,0 +1,6 @@
+export {
+  isMediaStoreAvailable,
+  saveToDownloads,
+  openDownload,
+  openDownloadsFolder
+} from './src/MediaStoreModule'

--- a/apps/mobile/modules/media-store/package.json
+++ b/apps/mobile/modules/media-store/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "media-store",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/apps/mobile/modules/media-store/src/MediaStoreModule.ts
+++ b/apps/mobile/modules/media-store/src/MediaStoreModule.ts
@@ -1,0 +1,35 @@
+import { requireOptionalNativeModule } from 'expo-modules-core'
+
+interface MediaStoreNativeModule {
+  saveToDownloads(srcPath: string, fileName: string, mimeType: string): Promise<string>
+  openDownload(contentUri: string, mimeType: string): Promise<void>
+  openDownloadsFolder(): Promise<void>
+}
+
+const nativeModule = requireOptionalNativeModule<MediaStoreNativeModule>('MediaStore')
+
+function requireModule(): MediaStoreNativeModule {
+  if (!nativeModule) throw new Error('MediaStore is only available on Android')
+  return nativeModule
+}
+
+export function isMediaStoreAvailable(): boolean {
+  return nativeModule != null
+}
+
+/** Streams a local file into the public Downloads collection. Returns the MediaStore content URI. */
+export function saveToDownloads(
+  srcPath: string,
+  fileName: string,
+  mimeType: string
+): Promise<string> {
+  return requireModule().saveToDownloads(srcPath, fileName, mimeType)
+}
+
+export function openDownload(contentUri: string, mimeType: string): Promise<void> {
+  return requireModule().openDownload(contentUri, mimeType)
+}
+
+export function openDownloadsFolder(): Promise<void> {
+  return requireModule().openDownloadsFolder()
+}

--- a/apps/mobile/src/transfer/receive/utils/completionToast.ts
+++ b/apps/mobile/src/transfer/receive/utils/completionToast.ts
@@ -1,6 +1,7 @@
 import { Linking, Platform } from 'react-native'
 import type { SaveDestination } from '@altersend/domain'
 import { i18nextInstance } from '@altersend/locales'
+import { openDownloadsFolder } from '@/modules/media-store'
 import type { ShowToastInput } from '@/src/components/Toast'
 
 interface BuildCompletionToastInput {
@@ -27,9 +28,10 @@ export function buildCompletionToast({
   if (count === 0) return null
 
   const photosCount = destinations.filter((d) => d === 'photos').length
-  const filesystemCount = destinations.filter((d) => d === 'filesystem').length
+  const nonPhotosCount = count - photosCount
+  const hasDownloads = destinations.some((d) => d === 'downloads')
 
-  if (photosCount > 0 && filesystemCount > 0) {
+  if (photosCount > 0 && nonPhotosCount > 0) {
     return {
       title: i18nextInstance.t('receive:summary.filesSaved', { count }),
       hint:
@@ -52,11 +54,17 @@ export function buildCompletionToast({
     }
   }
 
+  const showDownloadsAction = Platform.OS === 'android' && hasDownloads
+
   return {
     title: i18nextInstance.t('receive:summary.savedInFiles', { count }),
     hint: Platform.OS === 'ios' ? i18nextInstance.t('common:files.alterSendFolder') : undefined,
-    actionLabel: Platform.OS === 'android' ? i18nextInstance.t('receive:actions.open') : undefined,
-    onPress: Platform.OS === 'ios' ? openFiles : undefined,
+    actionLabel: showDownloadsAction ? i18nextInstance.t('receive:actions.open') : undefined,
+    onPress: showDownloadsAction
+      ? () => void openDownloadsFolder().catch(() => {})
+      : Platform.OS === 'ios'
+        ? openFiles
+        : undefined,
     durationMs: LONG_DURATION_MS
   }
 }

--- a/apps/mobile/src/transfer/receive/utils/downloadHandlers.ts
+++ b/apps/mobile/src/transfer/receive/utils/downloadHandlers.ts
@@ -1,5 +1,7 @@
+import { Platform } from 'react-native'
 import * as MediaLibrary from 'expo-media-library'
 import type { SaveDestination } from '@altersend/domain'
+import { isMediaStoreAvailable, saveToDownloads } from '@/modules/media-store'
 
 const IMAGE_EXTENSIONS = new Set([
   'jpg',
@@ -26,6 +28,31 @@ function isMediaFile(fileName: string): boolean {
   return IMAGE_EXTENSIONS.has(ext) || VIDEO_EXTENSIONS.has(ext)
 }
 
+const MIME_BY_EXT: Record<string, string> = {
+  pdf: 'application/pdf',
+  zip: 'application/zip',
+  rar: 'application/vnd.rar',
+  '7z': 'application/x-7z-compressed',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  txt: 'text/plain',
+  csv: 'text/csv',
+  json: 'application/json',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  apk: 'application/vnd.android.package-archive'
+}
+
+export function guessMimeType(fileName: string): string {
+  return MIME_BY_EXT[getExtension(fileName)] ?? 'application/octet-stream'
+}
+
 function toFilePath(uri: string): string {
   if (uri.startsWith('file://')) return uri
   return `file://${uri}`
@@ -42,6 +69,17 @@ export async function handleDownloadedFile(
   fileName: string
 ): Promise<HandleDownloadedFileResult> {
   if (!isMediaFile(fileName)) {
+    // Android: stream into the public Downloads collection so it's browsable in Files.
+    // iOS exposes the app's Documents dir via the Files app already, so no export is needed.
+    if (Platform.OS === 'android' && isMediaStoreAvailable()) {
+      try {
+        const contentUri = await saveToDownloads(localPath, fileName, guessMimeType(fileName))
+        return { intended: 'downloads', destination: 'downloads', localPath: contentUri }
+      } catch (err) {
+        console.warn('handleDownloadedFile: saveToDownloads failed, keeping private copy', err)
+        return { intended: 'downloads', destination: 'filesystem', localPath }
+      }
+    }
     return { intended: 'filesystem', destination: 'filesystem', localPath }
   }
 

--- a/apps/mobile/src/transfer/receive/utils/fileRowUtils.tsx
+++ b/apps/mobile/src/transfer/receive/utils/fileRowUtils.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Pressable, StyleSheet } from 'react-native'
+import { Platform, Pressable, StyleSheet } from 'react-native'
 import { getFileKind, useTheme } from '@altersend/components'
 import { formatFileSize, type DownloadItemState } from '@altersend/domain'
 import { useTranslation } from '@altersend/locales'
@@ -17,7 +17,8 @@ function getActionLabel(name: string, t: Translate): string {
 function getDestinationLabel(state: DownloadItemState | undefined, t: Translate): string {
   if (!state || state.destination === undefined) return ''
   if (state.destination === 'photos') return t('common:files.photos')
-  return t('common:files.downloads')
+  if (state.destination === 'downloads') return t('common:files.downloads')
+  return Platform.OS === 'ios' ? t('common:files.alterSendFolder') : t('common:files.files')
 }
 
 export function getFileMeta(

--- a/apps/mobile/src/transfer/receive/utils/openCompletedFile.ts
+++ b/apps/mobile/src/transfer/receive/utils/openCompletedFile.ts
@@ -1,6 +1,8 @@
 import { Linking, Platform } from 'react-native'
 import * as Sharing from 'expo-sharing'
 import { transferStore } from '@altersend/domain'
+import { openDownload } from '@/modules/media-store'
+import { guessMimeType } from './downloadHandlers'
 
 function openPhotos(): void {
   const url = Platform.OS === 'ios' ? 'photos-redirect://' : 'content://media/internal/images/media'
@@ -8,11 +10,20 @@ function openPhotos(): void {
 }
 
 export function openCompletedFile(offerKey: string): void {
-  const item = transferStore.getState().receiveDownloadStates[offerKey]
+  const state = transferStore.getState()
+  const item = state.receiveDownloadStates[offerKey]
   if (!item || item.status !== 'completed' || !item.savedTo) return
 
   if (item.destination === 'photos') {
     openPhotos()
+    return
+  }
+
+  if (item.destination === 'downloads') {
+    const offer = state.incomingFileOffers.find((f) => f.id === offerKey)
+    void openDownload(item.savedTo, guessMimeType(offer?.name ?? '')).catch((err) =>
+      console.error('openCompletedFile: openDownload failed', err)
+    )
     return
   }
 

--- a/packages/domain/src/receive/downloadModel.ts
+++ b/packages/domain/src/receive/downloadModel.ts
@@ -3,7 +3,7 @@ import { formatFileSize } from '../format'
 
 export type DownloadStatus = 'idle' | 'downloading' | 'completed' | 'failed'
 
-export type SaveDestination = 'filesystem' | 'photos'
+export type SaveDestination = 'filesystem' | 'photos' | 'downloads'
 
 export interface DownloadItemState {
   status: DownloadStatus


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for saving transferred files to Android's Downloads folder with automatic file type detection
  * Users can now open downloaded files and access the Downloads folder directly from the app
  * Updated file transfer completion notifications to support the Downloads destination with contextual actions and labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->