### PR TITLE
Added folders/files selection for win/linux

### DIFF
--- a/apps/desktop/src/electron/ipc.ts
+++ b/apps/desktop/src/electron/ipc.ts
@@ -87,6 +87,12 @@ async function collectFolderFiles(rootDir: string): Promise<PickedFile[]> {
   return files
 }
 
+const PICK_PROPERTIES: Record<PickMode, OpenDialogOptions['properties']> = {
+  files: ['openFile', 'multiSelections'],
+  folders: ['openDirectory', 'multiSelections'],
+  combined: ['openFile', 'openDirectory', 'multiSelections']
+}
+
 export function registerIpcHandlers(runtime: DesktopRuntime) {
   ipcMain.on('pkg', (evt) => {
     evt.returnValue = runtime.metadata.pkg
@@ -109,12 +115,9 @@ export function registerIpcHandlers(runtime: DesktopRuntime) {
     return runtime.disconnectWorker(filename)
   })
 
-  ipcMain.handle('app:pickFiles', async (evt) => {
+  ipcMain.handle('app:pickFiles', async (evt, mode?: PickMode) => {
     const parentWindow = BrowserWindow.fromWebContents(evt.sender) ?? undefined
-    const dialogOptions: OpenDialogOptions = {
-      title: 'Select files or folders to share',
-      properties: ['openFile', 'openDirectory', 'multiSelections']
-    }
+    const dialogOptions: OpenDialogOptions = { properties: PICK_PROPERTIES[mode ?? 'combined'] }
     const result = parentWindow
       ? await dialog.showOpenDialog(parentWindow, dialogOptions)
       : await dialog.showOpenDialog(dialogOptions)

--- a/apps/desktop/src/electron/preload.cjs
+++ b/apps/desktop/src/electron/preload.cjs
@@ -4,6 +4,7 @@ const P2P_WORKER = 'workers/main.js'
 
 contextBridge.exposeInMainWorld('bridge', {
   pkg: () => ipcRenderer.sendSync('pkg'),
+  platform: process.platform,
 
   startP2P: () => ipcRenderer.invoke('pear:startWorker', P2P_WORKER),
   disconnectP2P: () => ipcRenderer.invoke('pear:disconnectWorker', P2P_WORKER),
@@ -16,7 +17,7 @@ contextBridge.exposeInMainWorld('bridge', {
     return () => ipcRenderer.removeListener('pear:worker:event:' + P2P_WORKER, listener)
   },
 
-  pickFiles: () => ipcRenderer.invoke('app:pickFiles'),
+  pickFiles: (mode) => ipcRenderer.invoke('app:pickFiles', mode),
   pickDirectory: () => ipcRenderer.invoke('app:pickDirectory'),
   pickSaveFile: (defaultName) => {
     if (typeof defaultName !== 'string' || defaultName.length === 0 || defaultName.length > 255) {

--- a/apps/desktop/src/renderer/api/bridgeApi.ts
+++ b/apps/desktop/src/renderer/api/bridgeApi.ts
@@ -43,8 +43,11 @@ export const bridgeApi = {
   onTransferEvent(cb: (message: RendererTransferEvent) => void) {
     return requireBridge().onTransferEvent(cb)
   },
-  pickFiles() {
-    return requireBridge().pickFiles()
+  platform(): NodeJS.Platform {
+    return hasBridge() ? requireBridge().platform : 'darwin'
+  },
+  pickFiles(mode?: PickMode) {
+    return requireBridge().pickFiles(mode)
   },
   pickDirectory() {
     return requireBridge().pickDirectory()

--- a/apps/desktop/src/renderer/components/AddFilesModal/AddFilesModal.tsx
+++ b/apps/desktop/src/renderer/components/AddFilesModal/AddFilesModal.tsx
@@ -1,5 +1,6 @@
 import { LinkRow, useTheme } from '@altersend/components'
 import { FileIcon, FolderIcon } from '@altersend/components/icons'
+import { useTranslation } from '@altersend/locales'
 import { Modal } from '../Modal'
 
 interface AddFilesModalProps {
@@ -9,18 +10,19 @@ interface AddFilesModalProps {
 }
 
 export function AddFilesModal({ open, onClose, onSelect }: AddFilesModalProps) {
+  const { t } = useTranslation(['send', 'common'])
   const { theme } = useTheme()
   const c = theme.colors
 
   return (
-    <Modal open={open} title='What do you want to add?' width={460} onClose={onClose}>
+    <Modal open={open} title={t('send:dropzone.addTitle')} width={460} onClose={onClose}>
       <div className='flex flex-col gap-2 px-4 pb-4'>
         <LinkRow
           standalone
           icon={<FileIcon size={20} color={c.colorTextSecondary} />}
           iconBackground={c.colorSurfacePrimary}
-          label='Files'
-          subtitle='Pick one or more files'
+          label={t('common:files.files')}
+          subtitle={t('send:dropzone.filesHint')}
           trailing={null}
           onPress={() => onSelect('files')}
         />
@@ -28,8 +30,8 @@ export function AddFilesModal({ open, onClose, onSelect }: AddFilesModalProps) {
           standalone
           icon={<FolderIcon size={20} color={c.colorTextSecondary} />}
           iconBackground={c.colorSurfacePrimary}
-          label='Folder'
-          subtitle='Send an entire folder'
+          label={t('common:files.folder')}
+          subtitle={t('send:dropzone.folderHint')}
           trailing={null}
           onPress={() => onSelect('folders')}
         />

--- a/apps/desktop/src/renderer/components/AddFilesModal/AddFilesModal.tsx
+++ b/apps/desktop/src/renderer/components/AddFilesModal/AddFilesModal.tsx
@@ -1,0 +1,39 @@
+import { LinkRow, useTheme } from '@altersend/components'
+import { FileIcon, FolderIcon } from '@altersend/components/icons'
+import { Modal } from '../Modal'
+
+interface AddFilesModalProps {
+  open: boolean
+  onClose: () => void
+  onSelect: (mode: Exclude<PickMode, 'combined'>) => void
+}
+
+export function AddFilesModal({ open, onClose, onSelect }: AddFilesModalProps) {
+  const { theme } = useTheme()
+  const c = theme.colors
+
+  return (
+    <Modal open={open} title='What do you want to add?' width={460} onClose={onClose}>
+      <div className='flex flex-col gap-2 px-4 pb-4'>
+        <LinkRow
+          standalone
+          icon={<FileIcon size={20} color={c.colorTextSecondary} />}
+          iconBackground={c.colorSurfacePrimary}
+          label='Files'
+          subtitle='Pick one or more files'
+          trailing={null}
+          onPress={() => onSelect('files')}
+        />
+        <LinkRow
+          standalone
+          icon={<FolderIcon size={20} color={c.colorTextSecondary} />}
+          iconBackground={c.colorSurfacePrimary}
+          label='Folder'
+          subtitle='Send an entire folder'
+          trailing={null}
+          onPress={() => onSelect('folders')}
+        />
+      </div>
+    </Modal>
+  )
+}

--- a/apps/desktop/src/renderer/components/AddFilesModal/index.ts
+++ b/apps/desktop/src/renderer/components/AddFilesModal/index.ts
@@ -1,0 +1,1 @@
+export * from './AddFilesModal'

--- a/apps/desktop/src/renderer/components/index.ts
+++ b/apps/desktop/src/renderer/components/index.ts
@@ -1,3 +1,4 @@
+export * from './AddFilesModal'
 export * from './InviteBanner'
 export * from './Modal'
 export * from './PairDeviceModal'

--- a/apps/desktop/src/renderer/pages/SendPage/SelectFilesView.tsx
+++ b/apps/desktop/src/renderer/pages/SendPage/SelectFilesView.tsx
@@ -22,6 +22,7 @@ import {
   useTransferStore,
   type SendComposeMode
 } from '@altersend/domain'
+import { AddFilesModal } from '../../components'
 import { bridgeApi } from '../../api/bridgeApi'
 
 function readAllEntries(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
@@ -73,6 +74,9 @@ export function SelectFilesView({ mode = 'files' }: { mode?: SendComposeMode }) 
   const [isDropZoneDragging, setIsDropZoneDragging] = useState(false)
   const [selectionError, setSelectionError] = useState<string | null>(null)
   const [textInput, setTextInput] = useState('')
+  const [pickerModalOpen, setPickerModalOpen] = useState(false)
+
+  const splitPicker = bridgeApi.platform() !== 'darwin'
 
   const hasSelectedFiles = selectedFiles.length > 0
   const trimmedText = textInput.trim()
@@ -101,8 +105,8 @@ export function SelectFilesView({ mode = 'files' }: { mode?: SendComposeMode }) 
     return [type, sizeStr].filter(Boolean).join(' · ')
   }
 
-  const browse = async () => {
-    const selected = await bridgeApi.pickFiles()
+  const runPicker = async (mode: PickMode) => {
+    const selected = await bridgeApi.pickFiles(mode)
     if (!selected) return
 
     const normalizedFiles = normalizeSelectedFiles(selected, bridgeApi.getPathForFile)
@@ -111,6 +115,9 @@ export function SelectFilesView({ mode = 'files' }: { mode?: SendComposeMode }) 
       addSelectedFiles(normalizedFiles)
     }
   }
+
+  const pick = (mode: PickMode) =>
+    runPicker(mode).catch((err) => console.error('pickFiles failed', err))
 
   const onDrop = (event: React.DragEvent) => {
     event.preventDefault()
@@ -185,22 +192,32 @@ export function SelectFilesView({ mode = 'files' }: { mode?: SendComposeMode }) 
             }
           />
         ) : (
-          <FileDropZone
-            description={browseDescription}
-            hasFiles={hasSelectedFiles}
-            isDragging={isDropZoneDragging}
-            onClick={() => void browse()}
-            onDragLeave={(event) => {
-              event.preventDefault()
-              setIsDropZoneDragging(false)
-            }}
-            onDragOver={(event) => {
-              event.preventDefault()
-              setIsDropZoneDragging(true)
-            }}
-            onDrop={onDrop}
-            title={t('send:actions.dragAndDrop')}
-          />
+          <>
+            <FileDropZone
+              description={browseDescription}
+              hasFiles={hasSelectedFiles}
+              isDragging={isDropZoneDragging}
+              onClick={() => (splitPicker ? setPickerModalOpen(true) : pick('combined'))}
+              onDragLeave={(event) => {
+                event.preventDefault()
+                setIsDropZoneDragging(false)
+              }}
+              onDragOver={(event) => {
+                event.preventDefault()
+                setIsDropZoneDragging(true)
+              }}
+              onDrop={onDrop}
+              title={t('send:actions.dragAndDrop')}
+            />
+            <AddFilesModal
+              open={pickerModalOpen}
+              onClose={() => setPickerModalOpen(false)}
+              onSelect={(pickMode) => {
+                setPickerModalOpen(false)
+                pick(pickMode)
+              }}
+            />
+          </>
         )}
       </div>
 

--- a/apps/desktop/src/types.d.ts
+++ b/apps/desktop/src/types.d.ts
@@ -53,8 +53,11 @@ declare global {
     ? Result
     : never
 
+  type PickMode = 'files' | 'folders' | 'combined'
+
   interface Bridge {
     pkg: () => { version: string }
+    platform: NodeJS.Platform
     startP2P: () => Promise<boolean>
     disconnectP2P: () => Promise<boolean>
     invokeTransfer: <T extends TransferMethod>(
@@ -62,7 +65,7 @@ declare global {
       ...args: TransferMethodArgs<T>
     ) => TransferMethodReturn<T>
     onTransferEvent: (cb: (message: RendererTransferEvent) => void) => () => void
-    pickFiles: () => Promise<PickedFile[] | null>
+    pickFiles: (mode?: PickMode) => Promise<PickedFile[] | null>
     pickDirectory: () => Promise<PickedFile | null>
     pickSaveFile: (defaultName: string) => Promise<PickedFile | null>
     getPathForFile: (file: File) => string

--- a/packages/locales/src/locales/de-DE/common.json
+++ b/packages/locales/src/locales/de-DE/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Verbindungscode"
   },
   "files": {
+    "folder": "Ordner",
     "count_one": "{{count}} Datei",
     "count_other": "{{count}} Dateien",
     "photos": "Fotos",

--- a/packages/locales/src/locales/de-DE/send.json
+++ b/packages/locales/src/locales/de-DE/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Gerät offline – erneut versuchen"
   },
   "dropzone": {
+    "addTitle": "Was möchten Sie hinzufügen?",
+    "filesHint": "Eine oder mehrere Dateien auswählen",
+    "folderHint": "Einen ganzen Ordner senden",
     "browseDescription": "oder <link>durchsuchen</link> Sie Ihren Computer",
     "tapTo": "Tippen zum",
     "addMoreLink": "Hinzufügen",

--- a/packages/locales/src/locales/en-GB/common.json
+++ b/packages/locales/src/locales/en-GB/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Connection code"
   },
   "files": {
+    "folder": "Folder",
     "count_one": "{{count}} file",
     "count_other": "{{count}} files",
     "photos": "Photos",

--- a/packages/locales/src/locales/en-GB/send.json
+++ b/packages/locales/src/locales/en-GB/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Device offline — try again"
   },
   "dropzone": {
+    "addTitle": "What do you want to add?",
+    "filesHint": "Pick one or more files",
+    "folderHint": "Send an entire folder",
     "browseDescription": "or <link>browse</link> your computer",
     "tapTo": "Tap to",
     "addMoreLink": "add more",

--- a/packages/locales/src/locales/en-US/common.json
+++ b/packages/locales/src/locales/en-US/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Connection code"
   },
   "files": {
+    "folder": "Folder",
     "count_one": "{{count}} file",
     "count_other": "{{count}} files",
     "photos": "Photos",

--- a/packages/locales/src/locales/en-US/send.json
+++ b/packages/locales/src/locales/en-US/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Device offline — try again"
   },
   "dropzone": {
+    "addTitle": "What do you want to add?",
+    "filesHint": "Pick one or more files",
+    "folderHint": "Send an entire folder",
     "browseDescription": "or <link>browse</link> your computer",
     "tapTo": "Tap to",
     "addMoreLink": "add more",

--- a/packages/locales/src/locales/es-419/common.json
+++ b/packages/locales/src/locales/es-419/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Código de conexión"
   },
   "files": {
+    "folder": "Carpeta",
     "count_one": "{{count}} archivo",
     "count_other": "{{count}} archivos",
     "photos": "Fotos",

--- a/packages/locales/src/locales/es-419/send.json
+++ b/packages/locales/src/locales/es-419/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Dispositivo sin conexión: inténtalo de nuevo"
   },
   "dropzone": {
+    "addTitle": "¿Qué quieres añadir?",
+    "filesHint": "Elige uno o más archivos",
+    "folderHint": "Envía una carpeta completa",
     "browseDescription": "o <link>explora</link> tu computadora",
     "tapTo": "Toca para",
     "addMoreLink": "agregar más",

--- a/packages/locales/src/locales/es-ES/common.json
+++ b/packages/locales/src/locales/es-ES/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Código de conexión"
   },
   "files": {
+    "folder": "Carpeta",
     "count_one": "{{count}} archivo",
     "count_other": "{{count}} archivos",
     "photos": "Fotos",

--- a/packages/locales/src/locales/es-ES/send.json
+++ b/packages/locales/src/locales/es-ES/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Dispositivo sin conexión: inténtalo de nuevo"
   },
   "dropzone": {
+    "addTitle": "¿Qué quieres añadir?",
+    "filesHint": "Elige uno o más archivos",
+    "folderHint": "Envía una carpeta completa",
     "browseDescription": "o <link>explora</link> tu ordenador",
     "tapTo": "Toca para",
     "addMoreLink": "añadir más",

--- a/packages/locales/src/locales/fr-FR/common.json
+++ b/packages/locales/src/locales/fr-FR/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Code de connexion"
   },
   "files": {
+    "folder": "Dossier",
     "count_one": "{{count}} fichier",
     "count_other": "{{count}} fichiers",
     "photos": "Photothèque",

--- a/packages/locales/src/locales/fr-FR/send.json
+++ b/packages/locales/src/locales/fr-FR/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Appareil hors ligne — réessayez"
   },
   "dropzone": {
+    "addTitle": "Que voulez-vous ajouter ?",
+    "filesHint": "Choisissez un ou plusieurs fichiers",
+    "folderHint": "Envoyer un dossier entier",
     "browseDescription": "ou <link>parcourez</link> votre ordinateur",
     "tapTo": "Touchez pour",
     "addMoreLink": "en ajouter",

--- a/packages/locales/src/locales/it-IT/common.json
+++ b/packages/locales/src/locales/it-IT/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Codice di connessione"
   },
   "files": {
+    "folder": "Cartella",
     "count_one": "{{count}} file",
     "count_other": "{{count}} file",
     "photos": "Foto",

--- a/packages/locales/src/locales/it-IT/send.json
+++ b/packages/locales/src/locales/it-IT/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Dispositivo offline — riprova"
   },
   "dropzone": {
+    "addTitle": "Cosa vuoi aggiungere?",
+    "filesHint": "Scegli uno o più file",
+    "folderHint": "Invia un'intera cartella",
     "browseDescription": "o <link>sfoglia</link> il tuo computer",
     "tapTo": "Tocca per",
     "addMoreLink": "aggiungerne altri",

--- a/packages/locales/src/locales/ja-JP/common.json
+++ b/packages/locales/src/locales/ja-JP/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "接続コード"
   },
   "files": {
+    "folder": "フォルダ",
     "count_one": "{{count}} 個のファイル",
     "count_other": "{{count}} 個のファイル",
     "photos": "写真",

--- a/packages/locales/src/locales/ja-JP/send.json
+++ b/packages/locales/src/locales/ja-JP/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "デバイスはオフラインです — もう一度お試しください"
   },
   "dropzone": {
+    "addTitle": "何を追加しますか？",
+    "filesHint": "1つ以上のファイルを選択",
+    "folderHint": "フォルダ全体を送信",
     "browseDescription": "または<link>コンピュータを参照</link>",
     "tapTo": "タップして",
     "addMoreLink": "さらに追加",

--- a/packages/locales/src/locales/ko-KR/common.json
+++ b/packages/locales/src/locales/ko-KR/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "연결 코드"
   },
   "files": {
+    "folder": "폴더",
     "count_one": "{{count}}개 파일",
     "count_other": "{{count}}개 파일",
     "photos": "사진",

--- a/packages/locales/src/locales/ko-KR/send.json
+++ b/packages/locales/src/locales/ko-KR/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "기기 오프라인 — 다시 시도하세요"
   },
   "dropzone": {
+    "addTitle": "무엇을 추가할까요?",
+    "filesHint": "파일 하나 이상 선택",
+    "folderHint": "폴더 전체 보내기",
     "browseDescription": "또는 <link>컴퓨터에서 찾아보기</link>",
     "tapTo": "탭하여",
     "addMoreLink": "더 추가",

--- a/packages/locales/src/locales/pt-BR/common.json
+++ b/packages/locales/src/locales/pt-BR/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "Código de conexão"
   },
   "files": {
+    "folder": "Pasta",
     "count_one": "{{count}} arquivo",
     "count_other": "{{count}} arquivos",
     "photos": "Fotos",

--- a/packages/locales/src/locales/pt-BR/send.json
+++ b/packages/locales/src/locales/pt-BR/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "Dispositivo off-line — tente novamente"
   },
   "dropzone": {
+    "addTitle": "O que você quer adicionar?",
+    "filesHint": "Escolha um ou mais arquivos",
+    "folderHint": "Envie uma pasta inteira",
     "browseDescription": "ou <link>navegue</link> no seu computador",
     "tapTo": "Toque para",
     "addMoreLink": "adicionar mais",

--- a/packages/locales/src/locales/zh-CN/common.json
+++ b/packages/locales/src/locales/zh-CN/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "连接代码"
   },
   "files": {
+    "folder": "文件夹",
     "count_one": "{{count}} 个文件",
     "count_other": "{{count}} 个文件",
     "photos": "照片",

--- a/packages/locales/src/locales/zh-CN/send.json
+++ b/packages/locales/src/locales/zh-CN/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "设备离线 — 请重试"
   },
   "dropzone": {
+    "addTitle": "要添加什么？",
+    "filesHint": "选择一个或多个文件",
+    "folderHint": "发送整个文件夹",
     "browseDescription": "或<link>浏览</link>你的电脑",
     "tapTo": "点按",
     "addMoreLink": "继续添加",

--- a/packages/locales/src/locales/zh-TW/common.json
+++ b/packages/locales/src/locales/zh-TW/common.json
@@ -51,6 +51,7 @@
     "connectionCode": "連線代碼"
   },
   "files": {
+    "folder": "資料夾",
     "count_one": "{{count}} 个文件",
     "count_other": "{{count}} 个文件",
     "photos": "照片",

--- a/packages/locales/src/locales/zh-TW/send.json
+++ b/packages/locales/src/locales/zh-TW/send.json
@@ -92,6 +92,9 @@
     "deviceOffline": "裝置離線 — 請重試"
   },
   "dropzone": {
+    "addTitle": "要新增什麼？",
+    "filesHint": "選擇一個或多個檔案",
+    "folderHint": "傳送整個資料夾",
     "browseDescription": "或<link>瀏覽</link>你的電腦",
     "tapTo": "點一下",
     "addMoreLink": "繼續新增",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Add” modal to choose between adding Files or a Folder.
  * File/folder picking now supports dedicated selection modes.
  * Desktop picker behavior adapts by platform for the most appropriate flow.
* **Improvements**
  * Continued preserving recursive folder selection and existing cancel/empty handling.
  * Updated file-picker API wiring to support mode-based selection.
* **Localization**
  * Added new dropzone and file/folder strings across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->