### PR TITLE
chore: update flatpak for v1.6.0, fix electron-builder version and update permission.

### DIFF
--- a/apps/desktop/electron-builder.linux.json
+++ b/apps/desktop/electron-builder.linux.json
@@ -1,6 +1,6 @@
 {
   "appId": "com.altersend.desktop",
-  "electronVersion": "40.2.1",
+  "electronVersion": "40.10.0",
   "electronDownload": {
     "cache": ".electron-dist"
   },

--- a/flatpak/com.altersend.AlterSend.metainfo.xml
+++ b/flatpak/com.altersend.AlterSend.metainfo.xml
@@ -49,6 +49,7 @@
   </screenshots>
 
   <releases>
+    <release version="1.6.0" date="2026-07-12"/>
     <release version="1.5.1" date="2026-07-06"/>
   </releases>
 

--- a/flatpak/com.altersend.AlterSend.yaml
+++ b/flatpak/com.altersend.AlterSend.yaml
@@ -26,6 +26,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=all
+  - --filesystem=~/.config/AlterSend:create
 
 modules:
   - name: altersend
@@ -67,17 +68,17 @@ modules:
       - node-modules.json
 
       - type: file
-        url: https://github.com/electron/electron/releases/download/v40.2.1/electron-v40.2.1-linux-x64.zip
-        sha256: 69a75d19902c6fd5acb5b37a77ca5762c46cd1811667369e35e9128b17dfb368
+        url: https://github.com/electron/electron/releases/download/v40.10.0/electron-v40.10.0-linux-x64.zip
+        sha256: 35efe7401822e8d2e474e13788a6191362c7494dd1f7ae327b70087e0768a667
         dest: apps/desktop/.electron-dist
-        dest-filename: electron-v40.2.1-linux-x64.zip
+        dest-filename: electron-v40.10.0-linux-x64.zip
         only-arches:
           - x86_64
 
       - type: file
-        url: https://github.com/electron/electron/releases/download/v40.2.1/electron-v40.2.1-linux-arm64.zip
-        sha256: 5afced5714ae8a8703f7836205d9aa5e816623c51ca80853314623703429426d
+        url: https://github.com/electron/electron/releases/download/v40.10.0/electron-v40.10.0-linux-arm64.zip
+        sha256: cb4454ae64f00f43cef86f57d38eff9a6cef7b1e0690debc1dc81323f98e6e63
         dest: apps/desktop/.electron-dist
-        dest-filename: electron-v40.2.1-linux-arm64.zip
+        dest-filename: electron-v40.10.0-linux-arm64.zip
         only-arches:
           - aarch64


### PR DESCRIPTION
## Summary

Updates the Flatpak manifest and AppStream metadata for the v1.6.0 release, fixes a bug where paired devices vanish on app restart within Flatpak, and syncs the hardcoded `electronVersion` in the builder config with `package-lock.json`.

## Changes

- Updated the electronVersion in `apps/desktop/electron-builder.linux.json` from `40.2.1` to `40.10.0` so it matches the lockfile. This makes sure both the Flatpak and AppImage builds are actually packaging the newer Electron version.
- Updated Flatpak offline cache zip downloads to `v40.10.0` with new SHA256 checksums.
- Added `--filesystem=~/.config/AlterSend:create` to the Flatpak manifest. This gives PearRuntime the tightly scoped permission it needs to persist device identity and paired devices across app restarts, without opening up the entire `xdg-config` directory.
- Added the `1.6.0` release entry to `flatpak/com.altersend.AlterSend.metainfo.xml`.

## Testing

- [x] Manually verified on desktop / mobile (specify which)
 - Verified on Linux desktop (Fedora 44 KDE, x64). The offline build completes successfully with Electron `40.10.0`, and paired devices now successfully persist across application restarts.


## Screenshots / recordings

N/A

## Related issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flatpak access to create and use the application configuration directory.

* **Bug Fixes**
  * Updated the Linux desktop runtime to Electron 40.10.0 for improved compatibility and reliability.

* **Documentation**
  * Added release metadata for version 1.6.0 to the Flatpak listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->