### PR TITLE
Wire new drive in the apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ AlterSend is built on [Hyperswarm](https://github.com/holepunchto/hyperswarm), a
 1. **A random 32-byte key is generated** for each transfer (`crypto.randomBytes(32)`). That 64-char hex string _is_ the join code you share.
 2. **Peers rendezvous on a hash of that key, not the key itself.** Both sides compute the same discovery key — a BLAKE2b hash derived from the join code — and join the DHT on that. The raw key never leaves your device, only its hash is published.
 3. **Public bootstrap nodes are the only entry point.** A handful of them get peers onto the DHT. After that, no central server is involved in discovery. Most transfers are direct peer-to-peer; when a direct connection can't be established — usually because both peers are behind symmetric NAT (for example both on a VPN) — the transfer falls back to a **relay** that forwards the already-encrypted stream between them without ever seeing file contents. It's on by default and can be turned off in Settings → Relay.
-4. **The connection is end-to-end encrypted.** Peers connect over a Noise-encrypted socket, and the sender shares its [Hyperdrive](https://github.com/holepunchto/hyperdrive) key over that channel. Files are imported into the sender's local Hyperdrive, replicated to the receiver's, then written out to disk — so in v1 each side needs roughly **2× the transfer size** in free space while a transfer runs. _(Working to improve this.)_
+4. **The connection is end-to-end encrypted.** Peers connect over a Noise-encrypted socket. The sender reads each file straight off disk in chunks and hashes every one with BLAKE2b; the receiver checks the hash and writes the chunk at its offset in the destination file.
 
 **Pair once, skip the code.** You can pair devices you own so future transfers go straight through — no code to scan or type. Pairing only stores a public device key, the secret stays in your OS keychain, and a paired device is recognized without exposing your identity to anyone else. See [docs/architecture.md](docs/architecture.md#remembered-devices--pairing) for the full design.
 
@@ -148,14 +148,14 @@ cp apps/mobile/.env.example apps/mobile/.env
 ### Run
 
 ```sh
-npm run dev           
-npm run mobile:start  
+npm run dev
+npm run mobile:start
 ```
 
 ### Build
 
 ```sh
-npm run desktop:build  
+npm run desktop:build
 ```
 
 Platform installers (`.dmg`, `.exe`, `.AppImage`) are produced by the release CI workflow — trigger manually from the Actions tab.
@@ -167,7 +167,8 @@ apps/
   desktop/    Electron app — main + renderer + Bare worklet
   mobile/     React Native / Expo app
 packages/
-  core/       P2P protocol — Hyperswarm, Hyperdrive, RPC
+  core/       P2P protocol — Hyperswarm, transfer orchestration, RPC
+  drive/      Chunked file transfer — reads and writes files in place
   domain/     State management — Zustand store, business logic
   components/ Cross-platform UI — React Strict DOM + Tailwind
   locales/   Shared locale metadata, i18next setup, and catalogs

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -26,11 +26,11 @@ The desktop app has two processes:
 
 **Renderer process** (`src/renderer/`) — React + Vite. The UI. Communicates with main via a typed IPC bridge (`preload.cjs`).
 
-**Bare worklet** (`packages/core/src/worklet/`) — a separate Bare (lightweight JS runtime) process that owns all P2P networking: Hyperswarm discovery, Hyperdrive transfers, RPC protocol. Main talks to it over IPC; the worklet pushes events back.
+**Bare worklet** (`packages/core/src/worklet/`) — a separate Bare (lightweight JS runtime) process that owns all P2P networking: Hyperswarm discovery, chunked file transfer, RPC protocol. Main talks to it over IPC; the worklet pushes events back.
 
 ```
 Renderer ─── IPC (preload) ─── Main ─── IPC ─── Bare worklet
-                                              (Hyperswarm / Hyperdrive)
+                                               (Hyperswarm / drive)
 ```
 
 ## Building installers

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -28,7 +28,7 @@ The desktop app has two processes:
 
 **Bare worklet** (`packages/core/src/worklet/`) — a separate Bare (lightweight JS runtime) process that owns all P2P networking: Hyperswarm discovery, chunked file transfer, RPC protocol. Main talks to it over IPC; the worklet pushes events back.
 
-```
+```text
 Renderer ─── IPC (preload) ─── Main ─── IPC ─── Bare worklet
                                                (Hyperswarm / drive)
 ```

--- a/knip.json
+++ b/knip.json
@@ -14,7 +14,12 @@
       "ignore": ["schema/**"]
     },
     "packages/drive": {
-      "entry": ["src/**/*.test.ts", "test/**/*.test.ts"]
+      "entry": ["src/**/*.test.ts", "test/**/*.test.ts"],
+      "ignoreDependencies": ["bare-fs"],
+      "ignoreUnresolved": [
+        "^#fs$",
+        "^#path$"
+      ]
     },
     "packages/domain": {
       "entry": ["src/**/*.test.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -27356,6 +27356,7 @@
       "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@altersend/drive": "1.6.0",
         "b4a": "^1.8.0",
         "bare-buffer": "^3.6.0",
         "bare-crypto": "^1.14.0",
@@ -27379,7 +27380,9 @@
         "protomux": "^3.5.1"
       },
       "devDependencies": {
+        "@hyperswarm/secret-stream": "^6.9.1",
         "@types/b4a": "^1.6.5",
+        "streamx": "^2.25.0",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.8"
@@ -27409,6 +27412,8 @@
       "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "bare-fs": "^4.7.0",
+        "bare-path": "^3.0.0",
         "blake2b": "^2.1.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27377,7 +27377,7 @@
         "hyperswarm": "^4.17.0",
         "localdrive": "^2.2.0",
         "mirror-drive": "^1.14.1",
-        "protomux": "^3.5.1"
+        "protomux": "^3.7.0"
       },
       "devDependencies": {
         "@hyperswarm/secret-stream": "^6.9.1",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,8 @@
 # @altersend/core
 
-The peer-to-peer protocol and transfer orchestration for AlterSend. Hosts a [Bare](https://bare.pears.com/) worklet that owns Hyperswarm peer discovery, Hyperdrive replication, and the wire protocol — isolated from Electron and React Native renderers.
+The peer-to-peer protocol and transfer orchestration for AlterSend. Hosts a [Bare](https://bare.pears.com/) worklet that owns Hyperswarm peer discovery, file transfer, and the wire protocol — isolated from Electron and React Native renderers.
+
+Bytes move over `@altersend/drive`: the sender reads chunks from the original file and the receiver writes them straight to the destination.
 
 ## Architecture
 
@@ -90,7 +92,7 @@ The worklet exports nothing — it sets up RPC over IPC and handles `SIGTERM`, `
 
 ## Storage
 
-The transfer corestore (the Hyperdrive working copy) is wiped on every disconnect — transfers do not resume across sessions, by design. What **does** persist: the device keypair (secret sealed in the OS keychain and injected via `initDeviceSecret`; only the public key + metadata hit disk) and the remembered-peer list (`RememberedPeerStore`, on HyperDB). Resumable transfers remain out of scope.
+The transfer corestore is wiped on every disconnect — transfers do not resume across sessions, by design. What **does** persist: the device keypair (secret sealed in the OS keychain and injected via `initDeviceSecret`; only the public key + metadata hit disk) and the remembered-peer list (`RememberedPeerStore`, on HyperDB). Resumable transfers remain out of scope.
 
 ## Security
 
@@ -98,8 +100,9 @@ Input that comes from peers (control messages) and from the renderer (download r
 
 - 64-hex-char check on every Hyperdrive key and Hyperswarm topic
 - File-name traversal check (no `/`, `\`, `..`, NUL byte, length > 255)
-- Per-file size cap (50 GB) and per-download timeout (30 min)
+- Bounded lengths on every wire field: ids 128, paths 4096, text 65536, display names 256, and 10,000 files per transfer. File size itself is not capped — only required to be a non-negative integer
 - Hyperdrive entry signature check against wire-claimed size — sender can't lie about file size
+- On drive transfers the same guarantee comes from the offer: the receiver rejects a `start` whose size differs, and every chunk is checked against its BLAKE2b hash before it is written
 
 **Out of scope:** no rate limit on inbound peer control messages. A connected peer already shares our transfer topic, so a flood of `download-progress` events is treated as a connectivity nuisance, not a security boundary. If your threat model includes hostile paired peers, gate or throttle in the host before forwarding to the renderer.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "schema": "node schema/build.cjs"
   },
   "dependencies": {
+    "@altersend/drive": "1.6.0",
     "b4a": "^1.8.0",
     "bare-buffer": "^3.6.0",
     "bare-crypto": "^1.14.0",
@@ -53,7 +54,9 @@
     "protomux": "^3.5.1"
   },
   "devDependencies": {
+    "@hyperswarm/secret-stream": "^6.9.1",
     "@types/b4a": "^1.6.5",
+    "streamx": "^2.25.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.8"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "hyperswarm": "^4.17.0",
     "localdrive": "^2.2.0",
     "mirror-drive": "^1.14.1",
-    "protomux": "^3.5.1"
+    "protomux": "^3.7.0"
   },
   "devDependencies": {
     "@hyperswarm/secret-stream": "^6.9.1",

--- a/packages/core/src/types.d.ts
+++ b/packages/core/src/types.d.ts
@@ -166,20 +166,41 @@ declare module 'protomux' {
       onmessage: (message: T) => void
     }): ProtomuxMessage<T>
     open(): void
+    close(): void
+    fullyOpened(): Promise<boolean>
+    readonly drained: boolean
   }
   export default class Protomux {
     static from(socket: unknown): Protomux
     createChannel(opts: {
       protocol: string
       onopen?: () => void
-      onclose?: () => void
+      onclose?: (isRemote: boolean) => void
     }): ProtomuxChannel | null
   }
 }
 
 declare module 'compact-encoding' {
+  export interface EncodingState {
+    start: number
+    end: number
+    buffer: Uint8Array | null
+  }
+  export interface Encoding<T> {
+    preencode(state: EncodingState, value: T): void
+    encode(state: EncodingState, value: T): void
+    decode(state: EncodingState): T
+  }
   export const json: unknown
-  const _default: { json: typeof json }
+  export const string: Encoding<string>
+  export const uint: Encoding<number>
+  export const raw: Encoding<Uint8Array>
+  const _default: {
+    json: typeof json
+    string: typeof string
+    uint: typeof uint
+    raw: typeof raw
+  }
   export default _default
 }
 

--- a/packages/core/src/types.test.d.ts
+++ b/packages/core/src/types.test.d.ts
@@ -1,0 +1,12 @@
+declare module '@hyperswarm/secret-stream' {
+  export default class SecretStream {
+    constructor(isInitiator: boolean, rawStream?: unknown)
+  }
+}
+
+declare module 'streamx' {
+  export class Duplex {
+    constructor(opts?: { write?(data: Uint8Array, cb: (err?: Error) => void): void })
+    push(data: Uint8Array): boolean
+  }
+}

--- a/packages/core/src/worklet/transfer/drive.test.ts
+++ b/packages/core/src/worklet/transfer/drive.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import SecretStream from '@hyperswarm/secret-stream'
+import Protomux from 'protomux'
+import { Duplex } from 'streamx'
+import { SenderSession, ReceiverSession } from '@altersend/drive'
+import type { ChunkReader, ChunkWriter } from '@altersend/drive'
+import type { PeerSocket } from 'hyperswarm'
+import { PeerDrive } from './drive'
+
+function socketPair(): [PeerSocket, PeerSocket] {
+  const a = new Duplex({
+    write(data: Uint8Array, cb: () => void) {
+      b.push(data)
+      cb()
+    }
+  })
+  const b = new Duplex({
+    write(data: Uint8Array, cb: () => void) {
+      a.push(data)
+      cb()
+    }
+  })
+  return [
+    new SecretStream(true, a) as unknown as PeerSocket,
+    new SecretStream(false, b) as unknown as PeerSocket
+  ]
+}
+
+class MemoryReader implements ChunkReader {
+  constructor(private readonly bytes: Uint8Array) {}
+  async size() {
+    return this.bytes.length
+  }
+  async read(offset: number, length: number) {
+    return this.bytes.subarray(offset, offset + length)
+  }
+  async close() {}
+}
+
+class MemoryWriter implements ChunkWriter {
+  bytes = new Uint8Array(0)
+  constructor(private readonly savedTo: string) {}
+  async allocate(size: number) {
+    if (this.bytes.length !== size) this.bytes = new Uint8Array(size)
+  }
+  async write(offset: number, data: Uint8Array) {
+    this.bytes.set(data, offset)
+  }
+  async readBack(offset: number, length: number) {
+    return this.bytes.subarray(offset, offset + length)
+  }
+  async finalize() {
+    return this.savedTo
+  }
+  async abort() {}
+}
+
+function payload(size: number): Uint8Array {
+  const bytes = new Uint8Array(size)
+  for (let i = 0; i < size; i++) bytes[i] = (i * 31 + 11) & 0xff
+  return bytes
+}
+
+describe('PeerDrive', () => {
+  it('negotiates support when both peers speak drive', async () => {
+    const [socketA, socketB] = socketPair()
+    const a = PeerDrive.create(socketA)!
+    const b = PeerDrive.create(socketB)!
+
+    expect(await a.supported).toBe(true)
+    expect(await b.supported).toBe(true)
+  })
+
+  it('reports unsupported against a peer that has no drive channel', async () => {
+    const [socketA, socketB] = socketPair()
+    const a = PeerDrive.create(socketA)!
+    Protomux.from(socketB)
+
+    expect(await a.supported).toBe(false)
+  })
+
+  it('carries a file end to end over the real protomux stream', async () => {
+    const [socketA, socketB] = socketPair()
+    const senderSide = PeerDrive.create(socketA)!
+    const receiverSide = PeerDrive.create(socketB)!
+
+    const input = payload(700 * 1024)
+    const writer = new MemoryWriter('/saved/one.bin')
+
+    const receiver = new ReceiverSession(writer, receiverSide.session('file-1'), {
+      transferId: 'file-1'
+    })
+    const sender = new SenderSession(new MemoryReader(input), senderSide.session('file-1'), {
+      transferId: 'file-1',
+      name: 'one.bin'
+    })
+
+    const [savedTo] = await Promise.all([receiver.receive(), sender.start()])
+
+    expect(savedTo).toBe('/saved/one.bin')
+    expect(Buffer.from(writer.bytes).equals(Buffer.from(input))).toBe(true)
+  })
+
+  it('keeps concurrent files on one channel separate', async () => {
+    const [socketA, socketB] = socketPair()
+    const senderSide = PeerDrive.create(socketA)!
+    const receiverSide = PeerDrive.create(socketB)!
+
+    const inputs = [payload(300 * 1024), payload(120 * 1024)]
+    const writers = [new MemoryWriter('/saved/a.bin'), new MemoryWriter('/saved/b.bin')]
+
+    const transfers = inputs.map((input, i) => {
+      const id = `file-${i}`
+      const receiver = new ReceiverSession(writers[i], receiverSide.session(id), { transferId: id })
+      const sender = new SenderSession(new MemoryReader(input), senderSide.session(id), {
+        transferId: id,
+        name: `${id}.bin`
+      })
+      return Promise.all([receiver.receive(), sender.start()])
+    })
+
+    await Promise.all(transfers)
+
+    expect(Buffer.from(writers[0].bytes).equals(Buffer.from(inputs[0]))).toBe(true)
+    expect(Buffer.from(writers[1].bytes).equals(Buffer.from(inputs[1]))).toBe(true)
+  })
+
+  it('cancels an in-flight serve() when the drive is destroyed', async () => {
+    const [socketA, socketB] = socketPair()
+    const senderSide = PeerDrive.create(socketA)!
+    PeerDrive.create(socketB)!
+
+    const dir = await mkdtemp(join(tmpdir(), 'peerdrive-'))
+    const src = join(dir, 'in.bin')
+    await writeFile(src, payload(64 * 1024))
+
+    const serving = senderSide.serve('file-x', 'in.bin', src)
+    await senderSide.supported
+
+    senderSide.destroy()
+
+    await expect(serving).rejects.toThrow('cancelled')
+    await rm(dir, { recursive: true, force: true })
+  })
+})

--- a/packages/core/src/worklet/transfer/drive.test.ts
+++ b/packages/core/src/worklet/transfer/drive.test.ts
@@ -1,12 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import SecretStream from '@hyperswarm/secret-stream'
 import Protomux from 'protomux'
 import { Duplex } from 'streamx'
-import { SenderSession, ReceiverSession } from '@altersend/drive'
-import type { ChunkReader, ChunkWriter } from '@altersend/drive'
+import { SenderSession, ReceiverSession, DiskReader, DiskWriter } from '@altersend/drive'
 import type { PeerSocket } from 'hyperswarm'
 import { PeerDrive } from './drive'
 
@@ -29,40 +28,26 @@ function socketPair(): [PeerSocket, PeerSocket] {
   ]
 }
 
-class MemoryReader implements ChunkReader {
-  constructor(private readonly bytes: Uint8Array) {}
-  async size() {
-    return this.bytes.length
-  }
-  async read(offset: number, length: number) {
-    return this.bytes.subarray(offset, offset + length)
-  }
-  async close() {}
-}
-
-class MemoryWriter implements ChunkWriter {
-  bytes = new Uint8Array(0)
-  constructor(private readonly savedTo: string) {}
-  async allocate(size: number) {
-    if (this.bytes.length !== size) this.bytes = new Uint8Array(size)
-  }
-  async write(offset: number, data: Uint8Array) {
-    this.bytes.set(data, offset)
-  }
-  async readBack(offset: number, length: number) {
-    return this.bytes.subarray(offset, offset + length)
-  }
-  async finalize() {
-    return this.savedTo
-  }
-  async abort() {}
-}
-
 function payload(size: number): Uint8Array {
   const bytes = new Uint8Array(size)
   for (let i = 0; i < size; i++) bytes[i] = (i * 31 + 11) & 0xff
   return bytes
 }
+
+let dir = ''
+
+async function sourceFile(name: string, size: number): Promise<[string, Uint8Array]> {
+  if (!dir) dir = await mkdtemp(join(tmpdir(), 'peerdrive-'))
+  const path = join(dir, name)
+  const bytes = payload(size)
+  await writeFile(path, bytes)
+  return [path, bytes]
+}
+
+afterEach(async () => {
+  if (dir) await rm(dir, { recursive: true, force: true })
+  dir = ''
+})
 
 describe('PeerDrive', () => {
   it('negotiates support when both peers speak drive', async () => {
@@ -87,21 +72,21 @@ describe('PeerDrive', () => {
     const senderSide = PeerDrive.create(socketA)!
     const receiverSide = PeerDrive.create(socketB)!
 
-    const input = payload(700 * 1024)
-    const writer = new MemoryWriter('/saved/one.bin')
+    const [src, input] = await sourceFile('in.bin', 700 * 1024)
+    const dst = join(dir, 'out.bin')
 
-    const receiver = new ReceiverSession(writer, receiverSide.session('file-1'), {
+    const receiver = new ReceiverSession(new DiskWriter(dst), receiverSide.session('file-1'), {
       transferId: 'file-1'
     })
-    const sender = new SenderSession(new MemoryReader(input), senderSide.session('file-1'), {
+    const sender = new SenderSession(new DiskReader(src), senderSide.session('file-1'), {
       transferId: 'file-1',
-      name: 'one.bin'
+      name: 'out.bin'
     })
 
     const [savedTo] = await Promise.all([receiver.receive(), sender.start()])
 
-    expect(savedTo).toBe('/saved/one.bin')
-    expect(Buffer.from(writer.bytes).equals(Buffer.from(input))).toBe(true)
+    expect(savedTo).toBe(dst)
+    expect(Buffer.from(await readFile(dst)).equals(Buffer.from(input))).toBe(true)
   })
 
   it('keeps concurrent files on one channel separate', async () => {
@@ -109,23 +94,27 @@ describe('PeerDrive', () => {
     const senderSide = PeerDrive.create(socketA)!
     const receiverSide = PeerDrive.create(socketB)!
 
-    const inputs = [payload(300 * 1024), payload(120 * 1024)]
-    const writers = [new MemoryWriter('/saved/a.bin'), new MemoryWriter('/saved/b.bin')]
+    const sources = [await sourceFile('a.bin', 300 * 1024), await sourceFile('b.bin', 120 * 1024)]
 
-    const transfers = inputs.map((input, i) => {
+    const transfers = sources.map(([src], i) => {
       const id = `file-${i}`
-      const receiver = new ReceiverSession(writers[i], receiverSide.session(id), { transferId: id })
-      const sender = new SenderSession(new MemoryReader(input), senderSide.session(id), {
+      const dst = join(dir, `out-${i}.bin`)
+      const receiver = new ReceiverSession(new DiskWriter(dst), receiverSide.session(id), {
+        transferId: id
+      })
+      const sender = new SenderSession(new DiskReader(src), senderSide.session(id), {
         transferId: id,
-        name: `${id}.bin`
+        name: `out-${i}.bin`
       })
       return Promise.all([receiver.receive(), sender.start()])
     })
 
     await Promise.all(transfers)
 
-    expect(Buffer.from(writers[0].bytes).equals(Buffer.from(inputs[0]))).toBe(true)
-    expect(Buffer.from(writers[1].bytes).equals(Buffer.from(inputs[1]))).toBe(true)
+    for (const [i, [, input]] of sources.entries()) {
+      const written = await readFile(join(dir, `out-${i}.bin`))
+      expect(Buffer.from(written).equals(Buffer.from(input))).toBe(true)
+    }
   })
 
   it('cancels an in-flight serve() when the drive is destroyed', async () => {
@@ -133,9 +122,7 @@ describe('PeerDrive', () => {
     const senderSide = PeerDrive.create(socketA)!
     PeerDrive.create(socketB)!
 
-    const dir = await mkdtemp(join(tmpdir(), 'peerdrive-'))
-    const src = join(dir, 'in.bin')
-    await writeFile(src, payload(64 * 1024))
+    const [src] = await sourceFile('in.bin', 64 * 1024)
 
     const serving = senderSide.serve('file-x', 'in.bin', src)
     await senderSide.supported
@@ -143,6 +130,5 @@ describe('PeerDrive', () => {
     senderSide.destroy()
 
     await expect(serving).rejects.toThrow('cancelled')
-    await rm(dir, { recursive: true, force: true })
   })
 })

--- a/packages/core/src/worklet/transfer/drive.ts
+++ b/packages/core/src/worklet/transfer/drive.ts
@@ -1,0 +1,135 @@
+import Protomux, { type ProtomuxMessage } from 'protomux'
+import c, { type Encoding } from 'compact-encoding'
+import type { PeerSocket } from 'hyperswarm'
+import {
+  sendFile,
+  type ChunkHeader,
+  type ControlMessage,
+  type DriveChannel
+} from '@altersend/drive'
+
+const DRIVE_PROTOCOL = 'altersend/drive'
+
+interface ChunkFrame extends ChunkHeader {
+  data: Uint8Array
+}
+
+const chunkEncoding: Encoding<ChunkFrame> = {
+  preencode(state, frame) {
+    c.string.preencode(state, frame.transferId)
+    c.uint.preencode(state, frame.index)
+    c.string.preencode(state, frame.hash)
+    c.raw.preencode(state, frame.data)
+  },
+  encode(state, frame) {
+    c.string.encode(state, frame.transferId)
+    c.uint.encode(state, frame.index)
+    c.string.encode(state, frame.hash)
+    c.raw.encode(state, frame.data)
+  },
+  decode(state) {
+    return {
+      transferId: c.string.decode(state),
+      index: c.uint.decode(state),
+      hash: c.string.decode(state),
+      data: c.raw.decode(state)
+    }
+  }
+}
+
+interface Session {
+  onMessage?: (message: ControlMessage) => void
+  onChunk?: (header: ChunkHeader, data: Uint8Array) => void
+}
+
+type ProtomuxChannelLike = NonNullable<ReturnType<Protomux['createChannel']>>
+
+export class PeerDrive {
+  private readonly channel: ProtomuxChannelLike
+  private readonly control: ProtomuxMessage<ControlMessage>
+  private readonly chunk: ProtomuxMessage<ChunkFrame>
+  private readonly sessions = new Map<string, Session>()
+  private readonly sends = new Map<string, AbortController>()
+
+  readonly supported: Promise<boolean>
+
+  private constructor(channel: ProtomuxChannelLike) {
+    this.channel = channel
+    this.control = channel.addMessage<ControlMessage>({
+      encoding: c.json,
+      onmessage: (message) => {
+        if (message && typeof message.transferId === 'string') {
+          this.sessions.get(message.transferId)?.onMessage?.(message)
+        }
+      }
+    })
+    this.chunk = channel.addMessage<ChunkFrame>({
+      encoding: chunkEncoding,
+      onmessage: ({ transferId, index, hash, data }) => {
+        this.sessions.get(transferId)?.onChunk?.({ transferId, index, hash }, data)
+      }
+    })
+    channel.open()
+    this.supported = channel.fullyOpened()
+  }
+
+  static create(socket: PeerSocket): PeerDrive | null {
+    const channel = Protomux.from(socket).createChannel({ protocol: DRIVE_PROTOCOL })
+    return channel ? new PeerDrive(channel) : null
+  }
+
+  session(fileId: string): DriveChannel {
+    const session: Session = {}
+    this.sessions.set(fileId, session)
+
+    return {
+      send: (message) => this.control.send(message),
+      sendChunk: (header, data) => this.chunk.send({ ...header, data }),
+      onMessage: (handler) => {
+        session.onMessage = handler
+      },
+      onChunk: (handler) => {
+        session.onChunk = handler
+      },
+      bufferedAmount: () => (this.channel.drained ? 0 : Number.POSITIVE_INFINITY),
+      close: () => {
+        this.sessions.delete(fileId)
+      }
+    }
+  }
+
+  async serve(fileId: string, name: string, localPath: string): Promise<void> {
+    if (this.sends.has(fileId)) return
+    const abort = new AbortController()
+
+    this.sends.set(fileId, abort)
+    let channel: DriveChannel | null = null
+
+    try {
+      if (!(await this.supported)) return
+      channel = this.session(fileId)
+
+      await sendFile(localPath, channel, {
+        transferId: fileId,
+        name,
+        signal: abort.signal
+      })
+    } finally {
+      channel?.close()
+      this.sends.delete(fileId)
+    }
+  }
+
+  cancel(): void {
+    for (const abort of this.sends.values()) abort.abort()
+  }
+
+  destroy(): void {
+    this.cancel()
+    this.sessions.clear()
+
+    try {
+      this.channel.close()
+    } catch {}
+  }
+}

--- a/packages/core/src/worklet/transfer/drive.ts
+++ b/packages/core/src/worklet/transfer/drive.ts
@@ -98,7 +98,7 @@ export class PeerDrive {
     }
   }
 
-  async serve(fileId: string, name: string, localPath: string): Promise<void> {
+  async serve(fileId: string, name: string, localPath: string | null): Promise<void> {
     if (this.sends.has(fileId)) return
     const abort = new AbortController()
 
@@ -107,6 +107,14 @@ export class PeerDrive {
 
     try {
       if (!(await this.supported)) return
+      if (!localPath) {
+        this.control.send({
+          type: 'cancel',
+          transferId: fileId,
+          reason: 'File is no longer readable on the sender'
+        })
+        return
+      }
       channel = this.session(fileId)
 
       await sendFile(localPath, channel, {
@@ -126,6 +134,9 @@ export class PeerDrive {
 
   destroy(): void {
     this.cancel()
+    for (const [transferId, session] of this.sessions) {
+      session.onMessage?.({ type: 'cancel', transferId, reason: 'Peer disconnected' })
+    }
     this.sessions.clear()
 
     try {

--- a/packages/core/src/worklet/transfer/orchestrator.ts
+++ b/packages/core/src/worklet/transfer/orchestrator.ts
@@ -289,10 +289,9 @@ export class TransferOrchestrator implements TransferRPC {
   }
 
   private serve(message: DownloadRequest, session: PeerSession): void {
-    const localPath = this.storage.sender.localPath(message.fileId)
-    if (!localPath || !session.drive) return
+    if (!session.drive) return
     session.drive
-      .serve(message.fileId, message.fileName, localPath)
+      .serve(message.fileId, message.fileName, this.storage.sender.localPath(message.fileId))
       .catch((err) => console.warn('TransferOrchestrator: drive send failed', err))
   }
 

--- a/packages/core/src/worklet/transfer/orchestrator.ts
+++ b/packages/core/src/worklet/transfer/orchestrator.ts
@@ -53,10 +53,12 @@ import {
   type PeerDownloadStatus
 } from './download-events'
 import type { DownloadLifecycleEvent, DownloaderCallbacks } from './download-events'
+import type { DriveChannel } from '@altersend/drive'
+import type { PeerDrive } from './drive'
 import { PeerIdentityStore } from './peer-identity-store'
 import { TransferStorage } from './storage'
 import { TransferSwarm, type PeerSession } from './swarm'
-import { isValidHexKey } from './utils'
+import { AbortError, isValidHexKey } from './utils'
 import {
   DeviceIdentityStore,
   type DeviceIdentityDefaults,
@@ -82,23 +84,10 @@ async function tryAsync(label: string, op: () => Promise<unknown>): Promise<void
   }
 }
 
-/**
- * TransferOrchestrator is the top-level orchestrator for the AlterSend P2P file transfer engine.
- *
- * It composes focused subsystems:
- *   - TransferSwarm   — Hyperswarm peer connectivity and control channels
- *   - TransferStorage — ephemeral Corestore/Hyperdrive plus the file sender/receiver
- *   - Discovery/Remember/Pairing coordinators — remembered devices and pairing
- *
- * TransferOrchestrator itself is responsible for:
- *   - Lifecycle (initialisation, destroy)
- *   - Active transfer state (replayed to peers that join mid-transfer)
- *   - IPC event emission to the renderer
- *   - The public command surface consumed by TransferWorkerRPCServer
- */
 export class TransferOrchestrator implements TransferRPC {
   private readonly emitIPC: (message: TransferIPCMessage | PeerControlMessage) => void
   private readonly storage: TransferStorage
+  private readonly offerPeers = new Map<string, string>()
 
   private readonly swarm: TransferSwarm
 
@@ -108,6 +97,7 @@ export class TransferOrchestrator implements TransferRPC {
   private currentTopic: string | null = null
   private suspended: boolean = false
   private inflightAbort: AbortController | null = null
+  private stagingAbort: AbortController | null = null
 
   private readonly deviceIdentityStore: DeviceIdentityStore
   private readonly rememberedStore: RememberedPeerStore
@@ -152,7 +142,7 @@ export class TransferOrchestrator implements TransferRPC {
           this.sendStatus('connection-type', { peer: peerKey, connectionType })
         }
       },
-      { identityStore }
+      { identityStore, drive: true }
     )
     this.discovery = new DiscoveryCoordinator({
       deviceIdentityStore: this.deviceIdentityStore,
@@ -201,7 +191,7 @@ export class TransferOrchestrator implements TransferRPC {
   private onPeerConnected(session: PeerSession): void {
     this.sendStatus('peer-connected', { peer: session.peerKey, peers: this.swarm.peerCount })
     if (this.activeTransfer) session.controlChannel.send(this.activeTransfer)
-    if (this.activeTransferReady) session.controlChannel.send(this.activeTransferReady)
+    this.offerTo(session)
     this.recognition.onPeerConnected(session.peerKey)
   }
 
@@ -265,6 +255,9 @@ export class TransferOrchestrator implements TransferRPC {
         console.warn(`TransferOrchestrator: dropping inbound ${message.type} in role=${this.role}`)
         return
       }
+      if (message.type === 'transfer-ready') {
+        this.offerPeers.set(message.transferId, session.peerKey)
+      }
       this.emitIPC(
         message.type === 'transfer-ready' ? { ...message, peer: session.peerKey } : message
       )
@@ -279,6 +272,7 @@ export class TransferOrchestrator implements TransferRPC {
     switch (message.type) {
       case 'download-request':
         this.forwardPeerDownloadStatus('peer-download-started', message, session)
+        this.serve(message, session)
         return
       case 'download-progress':
         this.forwardPeerDownloadStatus('peer-download-progress', message, session)
@@ -292,6 +286,25 @@ export class TransferOrchestrator implements TransferRPC {
       default:
         return
     }
+  }
+
+  private serve(message: DownloadRequest, session: PeerSession): void {
+    const localPath = this.storage.sender.localPath(message.fileId)
+    if (!localPath || !session.drive) return
+    session.drive
+      .serve(message.fileId, message.fileName, localPath)
+      .catch((err) => console.warn('TransferOrchestrator: drive send failed', err))
+  }
+
+  private async driveChannelFor(file: DownloadFileRequest): Promise<DriveChannel | null> {
+    const peerKey = this.offerPeers.get(file.transferId)
+    const drive = peerKey ? this.swarm.getSession(peerKey)?.drive : null
+    if (!drive || !(await this.speaksDrive(drive))) return null
+    return drive.session(file.fileId)
+  }
+
+  private speaksDrive(drive: PeerDrive | null | undefined): Promise<boolean> {
+    return drive ? drive.supported.catch(() => false) : Promise.resolve(false)
   }
 
   private setRole(role: TransferRole | null): void {
@@ -406,6 +419,9 @@ export class TransferOrchestrator implements TransferRPC {
     }
 
     await this.storage.ready()
+    this.stagingAbort?.abort()
+    this.stagingAbort = null
+    await this.storage.sender.reset()
 
     try {
       const fileRequests = requests.filter((r) => r.kind !== 'text')
@@ -432,45 +448,59 @@ export class TransferOrchestrator implements TransferRPC {
       this.swarm.broadcast(this.activeTransfer)
       this.sendStatus('sharing', { transferId })
 
-      const controller = new AbortController()
-      this.inflightAbort = controller
+      const offers: TransferOffer[] = this.storage.sender.buildOffers(files, transferId)
 
-      try {
-        const offers: TransferOffer[] = await this.storage.sender.stageFiles(
-          files,
+      for (const req of textRequests) {
+        if (!req.content || req.content.trim() === '') continue
+        const textOffer: TextOffer = {
+          id: createTransferId(),
           transferId,
-          (file) => {
-            this.sendStatus('sharing', { file: file.fileName, path: file.inputPath, transferId })
-          },
-          controller.signal
-        )
-
-        for (const req of textRequests) {
-          if (!req.content || req.content.trim() === '') continue
-          const textOffer: TextOffer = {
-            id: createTransferId(),
-            transferId,
-            kind: 'text',
-            content: req.content
-          }
-          offers.push(textOffer)
+          kind: 'text',
+          content: req.content
         }
-
-        this.activeTransferReady = { type: 'transfer-ready', transferId, files: offers }
-        this.swarm.broadcast(this.activeTransferReady)
-
-        return { acceptedFiles: offers.length }
-      } catch (err) {
-        this.activeTransfer = null
-        this.activeTransferReady = null
-        this.setRole(null)
-        throw err
-      } finally {
-        this.inflightAbort = null
+        offers.push(textOffer)
       }
-    } finally {
-      await this.storage.sender.closeSourceDrives()
+
+      this.activeTransferReady = { type: 'transfer-ready', transferId, files: offers }
+      for (const session of this.swarm.sessions) this.offerTo(session)
+
+      return { acceptedFiles: offers.length }
+    } catch (err) {
+      this.activeTransfer = null
+      this.activeTransferReady = null
+      this.setRole(null)
+      throw err
     }
+  }
+
+  private offerTo(session: PeerSession): void {
+    const ready = this.activeTransferReady
+    if (!ready) return
+
+    this.prepareFor(session)
+      .then(() => {
+        if (this.activeTransferReady !== ready) return
+        session.controlChannel.send(ready)
+      })
+      .catch((err) => {
+        if (err instanceof AbortError) return
+        console.warn('TransferOrchestrator: staging for peer failed', err)
+        this.sendError(err instanceof Error ? err.message : String(err))
+      })
+  }
+
+  private async prepareFor(session: PeerSession): Promise<void> {
+    if (await this.speaksDrive(session.drive)) return
+
+    const transferId = this.activeTransferReady?.transferId
+    const controller = this.stagingAbort ?? new AbortController()
+    this.stagingAbort = controller
+
+    await this.storage.sender.stageForLegacyPeers(
+      (file) =>
+        this.sendStatus('sharing', { file: file.fileName, path: file.inputPath, transferId }),
+      controller.signal
+    )
   }
 
   async downloadFiles(files: DownloadFileRequest[]): Promise<DownloadFilesReply> {
@@ -487,7 +517,8 @@ export class TransferOrchestrator implements TransferRPC {
       const results = await this.storage.receiver.downloadFiles(
         files,
         this.getDownloaderCallbacks(),
-        controller.signal
+        controller.signal,
+        (file) => this.driveChannelFor(file)
       )
       return { files: results }
     } finally {
@@ -496,6 +527,10 @@ export class TransferOrchestrator implements TransferRPC {
   }
 
   abortInFlight(): void {
+    for (const session of this.swarm.sessions) session.drive?.cancel()
+    this.stagingAbort?.abort()
+    this.stagingAbort = null
+
     const controller = this.inflightAbort
     if (!controller) return
 
@@ -512,8 +547,10 @@ export class TransferOrchestrator implements TransferRPC {
       this.activeTransfer = null
       this.activeTransferReady = null
       this.currentTopic = null
+      this.offerPeers.clear()
 
       await this.swarm.endSession()
+      await this.storage.sender.reset()
       await this.storage.receiver.reset()
       await this.storage.wipeAndReinit()
 
@@ -530,6 +567,7 @@ export class TransferOrchestrator implements TransferRPC {
     this.recognition.reset()
     this.remember.reset()
     this.currentTopic = null
+    this.offerPeers.clear()
     await this.swarm.endSession()
   }
 

--- a/packages/core/src/worklet/transfer/receiver.ts
+++ b/packages/core/src/worklet/transfer/receiver.ts
@@ -2,6 +2,7 @@ import Hyperdrive from 'hyperdrive'
 import type Corestore from 'corestore'
 import b4a from 'b4a'
 import fs from 'bare-fs'
+import { receiveFile, type DriveChannel } from '@altersend/drive'
 import {
   AbortError,
   getDirname,
@@ -10,12 +11,39 @@ import {
   isSafeRelativePath,
   isValidHexKey,
   joinFilePath,
+  onAbort,
   toRelativePath
 } from './utils'
 import type { DownloadFileRequest, DownloadFileResult } from '../rpc/protocol'
 import type { DownloaderCallbacks } from './download-events'
 
-type DownloadFileOutcome = { ok: true } | { ok: false; message: string }
+type DownloadFileOutcome = { ok: true; savedTo: string } | { ok: false; message: string }
+
+function fileEvents(
+  file: DownloadFileRequest,
+  callbacks: DownloaderCallbacks,
+  targetPath: string,
+  totalBytes: number
+) {
+  const base = {
+    transferId: file.transferId,
+    fileId: file.fileId,
+    fileName: file.name ?? getFileName(file.path),
+    sourcePath: file.path,
+    targetPath,
+    totalBytes
+  }
+  return {
+    started: () => callbacks.onFileStart({ ...base, bytesTransferred: 0 }),
+    progressed: (bytesTransferred: number) =>
+      callbacks.onFileProgress({ ...base, bytesTransferred }),
+    completed: () => callbacks.onFileComplete({ ...base, bytesTransferred: totalBytes }),
+    failed: (message: string): DownloadFileOutcome => {
+      callbacks.onFileError({ ...base, message })
+      return { ok: false, message }
+    }
+  }
+}
 
 function getChunkSize(chunk: unknown): number {
   if (typeof chunk === 'string') return Buffer.byteLength(chunk)
@@ -30,16 +58,6 @@ function getChunkSize(chunk: unknown): number {
   return 0
 }
 
-/**
- * TransferReceiver handles the **receiver** side of a file transfer.
- *
- * Responsibilities:
- *   - Opening a remote Hyperdrive by its public key
- *   - Downloading file blobs from the remote drive via the shared Corestore
- *   - Writing the downloaded data to a target path on the local disk
- *
- * It has no knowledge of Hyperswarm, peer sessions, or file staging.
- */
 export class TransferReceiver {
   private readonly driveStore: Corestore
   private readonly remoteDrives: Map<string, Hyperdrive>
@@ -52,24 +70,17 @@ export class TransferReceiver {
   async downloadFiles(
     files: DownloadFileRequest[],
     callbacks: DownloaderCallbacks,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    driveFor?: (file: DownloadFileRequest) => Promise<DriveChannel | null>
   ): Promise<DownloadFileResult[]> {
     const results: DownloadFileResult[] = []
 
     for (const file of files) {
       const resolvedName = file.name ?? getFileName(file.path)
-      const fail = (fileName: string, targetPath: string, message: string) => {
-        callbacks.onFileError({
-          transferId: file.transferId,
-          fileId: file.fileId,
-          fileName,
-          sourcePath: file.path,
-          targetPath,
-          totalBytes: file.size ?? 0,
-          message
-        })
-        results.push({ fileId: file.fileId, fileName, ok: false, message })
-      }
+      const record = (outcome: DownloadFileOutcome) =>
+        results.push({ fileId: file.fileId, fileName: resolvedName, ...outcome })
+      const fail = (targetPath: string, message: string) =>
+        record(fileEvents(file, callbacks, targetPath, file.size ?? 0).failed(message))
 
       if (signal?.aborted) {
         results.push({
@@ -83,43 +94,29 @@ export class TransferReceiver {
 
       const relativeTarget = toRelativePath(file.path)
       if (!isSafeRelativePath(relativeTarget)) {
-        fail(
-          resolvedName,
-          file.targetPath ?? file.targetDir ?? '',
-          'Rejected unsafe file path from sender'
-        )
+        fail(file.targetPath ?? file.targetDir ?? '', 'Rejected unsafe file path from sender')
         continue
       }
 
       const candidatePath = file.targetPath ?? file.targetDir
       if (!isPathSafe(candidatePath)) {
-        fail(resolvedName, candidatePath ?? '', 'Rejected unsafe target path from renderer')
+        fail(candidatePath ?? '', 'Rejected unsafe target path from renderer')
         continue
       }
 
       const targetPath = file.targetPath ?? joinFilePath(file.targetDir!, relativeTarget)
 
       try {
-        const outcome = await this.downloadFile(file, targetPath, callbacks, signal)
-        if (outcome.ok) {
-          results.push({
-            fileId: file.fileId,
-            fileName: resolvedName,
-            ok: true,
-            savedTo: targetPath
-          })
-        } else {
-          results.push({
-            fileId: file.fileId,
-            fileName: resolvedName,
-            ok: false,
-            message: outcome.message
-          })
-        }
+        const channel = (await driveFor?.(file)) ?? null
+        record(
+          channel
+            ? await this.downloadViaDrive(file, targetPath, callbacks, channel, signal)
+            : await this.downloadFile(file, targetPath, callbacks, signal)
+        )
       } catch (error) {
         await this.evictRemoteDrive(file.driveKey)
 
-        fail(resolvedName, targetPath, error instanceof Error ? error.message : String(error))
+        fail(targetPath, error instanceof Error ? error.message : String(error))
       }
     }
 
@@ -134,69 +131,63 @@ export class TransferReceiver {
   ): Promise<DownloadFileOutcome> {
     const remoteDrive = await this.getRemoteDrive(file.driveKey)
     const resolvedName = file.name ?? getFileName(file.path)
-    const fail = (message: string, totalBytes: number = file.size ?? 0): DownloadFileOutcome => {
-      callbacks.onFileError({
-        transferId: file.transferId,
-        fileId: file.fileId,
-        fileName: resolvedName,
-        sourcePath: file.path,
-        targetPath,
-        totalBytes,
-        message
-      })
-      return { ok: false, message }
-    }
+    const announced = fileEvents(file, callbacks, targetPath, file.size ?? 0)
 
     const entry = await remoteDrive.entry(file.path)
     if (!entry?.value?.blob) {
-      return fail(`Could not find remote file: ${resolvedName}`)
+      return announced.failed(`Could not find remote file: ${resolvedName}`)
     }
 
     const actualBytes = entry.value.blob.byteLength
     if (typeof file.size === 'number' && file.size !== actualBytes) {
-      return fail(`Sender claimed ${file.size} bytes but file is ${actualBytes} bytes`, file.size)
+      return announced.failed(`Sender claimed ${file.size} bytes but file is ${actualBytes} bytes`)
     }
 
-    const totalBytes = actualBytes
-    callbacks.onFileStart({
-      transferId: file.transferId,
-      fileId: file.fileId,
-      fileName: resolvedName,
-      sourcePath: file.path,
-      targetPath,
-      totalBytes,
-      bytesTransferred: 0
-    })
+    const events = fileEvents(file, callbacks, targetPath, actualBytes)
+    events.started()
 
-    await this.writeToDisk(
+    const savedTo = await this.writeToDisk(
       remoteDrive,
       file.path,
       targetPath,
-      totalBytes,
-      (bytesTransferred) => {
-        callbacks.onFileProgress({
-          transferId: file.transferId,
-          fileId: file.fileId,
-          fileName: resolvedName,
-          sourcePath: file.path,
-          targetPath,
-          totalBytes,
-          bytesTransferred
-        })
-      },
+      actualBytes,
+      (bytesTransferred) => events.progressed(bytesTransferred),
       signal
     )
 
-    callbacks.onFileComplete({
-      transferId: file.transferId,
-      fileId: file.fileId,
-      fileName: resolvedName,
-      sourcePath: file.path,
-      targetPath,
-      totalBytes,
-      bytesTransferred: totalBytes
-    })
-    return { ok: true }
+    events.completed()
+    return { ok: true, savedTo }
+  }
+
+  private async downloadViaDrive(
+    file: DownloadFileRequest,
+    targetPath: string,
+    callbacks: DownloaderCallbacks,
+    channel: DriveChannel,
+    signal?: AbortSignal
+  ): Promise<DownloadFileOutcome> {
+    try {
+      const finalPath = await this.findUniqueTargetPath(targetPath)
+      const events = fileEvents(file, callbacks, finalPath, file.size ?? 0)
+
+      const pending = receiveFile(finalPath, channel, {
+        transferId: file.fileId,
+        expectedSize: file.size,
+        signal,
+        onProgress: (bytesTransferred) => events.progressed(bytesTransferred)
+      })
+
+      events.started()
+      try {
+        await pending
+        events.completed()
+        return { ok: true, savedTo: finalPath }
+      } catch (err) {
+        return events.failed(err instanceof Error ? err.message : String(err))
+      }
+    } finally {
+      channel.close()
+    }
   }
 
   private async evictRemoteDrive(driveKey: string): Promise<void> {
@@ -287,7 +278,7 @@ export class TransferReceiver {
     totalBytes: number,
     onProgress: (bytesTransferred: number) => void,
     signal?: AbortSignal
-  ): Promise<void> {
+  ): Promise<string> {
     const { default: Localdrive } = await import('localdrive')
     const destination = new Localdrive(getDirname(targetPath))
     const partName = `${getFileName(targetPath)}.part`
@@ -296,7 +287,7 @@ export class TransferReceiver {
     const readStream = remoteDrive.createReadStream(sourcePath)
     const writeStream = destination.createWriteStream(`/${partName}`)
 
-    let onAbort: (() => void) | undefined
+    let release = () => {}
 
     try {
       await new Promise<void>((resolve, reject) => {
@@ -312,19 +303,15 @@ export class TransferReceiver {
         }
 
         // Settle before destroying streams so the outer catch sees AbortError, not stream-destroyed.
-        if (signal) {
-          onAbort = () => {
-            finish(new AbortError())
-            try {
-              readStream.destroy()
-            } catch {}
-            try {
-              writeStream.destroy()
-            } catch {}
-          }
-          if (signal.aborted) onAbort()
-          else signal.addEventListener('abort', onAbort)
-        }
+        release = onAbort(signal, () => {
+          finish(new AbortError())
+          try {
+            readStream.destroy()
+          } catch {}
+          try {
+            writeStream.destroy()
+          } catch {}
+        })
 
         readStream.on('data', (chunk: unknown) => {
           bytesTransferred += getChunkSize(chunk)
@@ -355,10 +342,11 @@ export class TransferReceiver {
       }
       throw err
     } finally {
-      if (signal && onAbort) signal.removeEventListener('abort', onAbort)
+      release()
     }
 
     const finalPath = await this.findUniqueTargetPath(targetPath)
     await fs.promises.rename(partPath, finalPath)
+    return finalPath
   }
 }

--- a/packages/core/src/worklet/transfer/sender.test.ts
+++ b/packages/core/src/worklet/transfer/sender.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtemp, writeFile, stat, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type Hyperdrive from 'hyperdrive'
+import type Localdrive from 'localdrive'
+import { TransferSender, type ScannedFile } from './sender'
+
+function untouchableDrive(): Hyperdrive {
+  const key = new Uint8Array(32).fill(7)
+  return new Proxy(
+    { key },
+    {
+      get(target, prop) {
+        if (prop === 'key') return target.key
+        throw new Error(`Hyperdrive.${String(prop)} was used, so the file got copied`)
+      }
+    }
+  ) as unknown as Hyperdrive
+}
+
+function scanned(name: string, size: number): ScannedFile {
+  return {
+    fileName: name,
+    inputPath: `/src/${name}`,
+    sourcePath: `/${name}`,
+    sourceDrive: {} as Localdrive,
+    size
+  }
+}
+
+describe('TransferSender.buildOffers', () => {
+  it('describes files without copying them into the Hyperdrive', () => {
+    const sender = new TransferSender(untouchableDrive())
+
+    const offers = sender.buildOffers([scanned('a.bin', 10), scanned('b.bin', 20)], 't1')
+
+    expect(offers.map((offer) => offer.name)).toEqual(['a.bin', 'b.bin'])
+    expect(offers.map((offer) => offer.size)).toEqual([10, 20])
+    expect(offers.every((offer) => offer.transferId === 't1')).toBe(true)
+    expect(offers.every((offer) => offer.driveKey === '07'.repeat(32))).toBe(true)
+  })
+
+  it('maps each offer back to the file on disk so drive can read it', () => {
+    const sender = new TransferSender(untouchableDrive())
+
+    const [offer] = sender.buildOffers([scanned('a.bin', 10)], 't1')
+
+    expect(sender.localPath(offer.id)).toBe('/src/a.bin')
+    expect(sender.localPath('unknown')).toBeNull()
+  })
+
+  it('gives every offer a distinct id', () => {
+    const sender = new TransferSender(untouchableDrive())
+
+    const offers = sender.buildOffers([scanned('a.bin', 1), scanned('a.bin', 1)], 't1')
+
+    expect(offers[0].id).not.toBe(offers[1].id)
+  })
+})
+
+describe('TransferSender.reset', () => {
+  it('deletes temporary files even when a drive peer meant nothing was staged', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sender-temp-'))
+    const picked = join(dir, 'pic.jpg')
+    await writeFile(picked, 'x')
+
+    const sender = new TransferSender(untouchableDrive())
+    sender.buildOffers([{ ...scanned('pic.jpg', 1), inputPath: picked, isTemporary: true }], 't1')
+
+    await sender.reset()
+
+    await expect(stat(picked)).rejects.toThrow()
+    await rm(dir, { recursive: true, force: true })
+  })
+})
+
+describe('TransferSender.stageForLegacyPeers', () => {
+  it('runs again for a later peer after a run was aborted', async () => {
+    const sender = new TransferSender(untouchableDrive())
+    sender.buildOffers([{ ...scanned('a.bin', 1), alreadyStaged: true }], 't1')
+
+    const cancelled = new AbortController()
+    cancelled.abort()
+    await expect(sender.stageForLegacyPeers(() => {}, cancelled.signal)).rejects.toThrow()
+
+    const onStaging = vi.fn()
+    await sender.stageForLegacyPeers(onStaging, new AbortController().signal)
+    expect(onStaging).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports every file, including ones already in the drive', async () => {
+    const sender = new TransferSender(untouchableDrive())
+    sender.buildOffers(
+      [
+        { ...scanned('a.bin', 1), alreadyStaged: true },
+        { ...scanned('b.bin', 2), alreadyStaged: true }
+      ],
+      't1'
+    )
+
+    const onStaging = vi.fn()
+    await sender.stageForLegacyPeers(onStaging, new AbortController().signal)
+
+    expect(onStaging.mock.calls.map(([file]) => file.fileName)).toEqual(['a.bin', 'b.bin'])
+  })
+})
+
+describe('TransferSender staging races', () => {
+  it('leaves a newer share alone when an older run finishes importing', async () => {
+    let letImportFinish!: () => void
+    const stuck = new Promise<void>((resolve) => {
+      letImportFinish = resolve
+    })
+    const importing = vi
+      .spyOn(
+        TransferSender.prototype as unknown as { importToDrive: () => Promise<void> },
+        'importToDrive'
+      )
+      .mockImplementation(() => stuck)
+
+    try {
+      const sender = new TransferSender(untouchableDrive())
+      sender.buildOffers([scanned('old.bin', 1)], 'old')
+      const old = sender.stageForLegacyPeers(() => {}, new AbortController().signal)
+
+      await sender.reset()
+      sender.buildOffers([scanned('new.bin', 1)], 'new')
+
+      letImportFinish()
+      await old
+
+      const seen = vi.fn()
+      await sender.stageForLegacyPeers(seen, new AbortController().signal)
+      expect(seen.mock.calls.map(([file]) => file.fileName)).toEqual(['new.bin'])
+    } finally {
+      importing.mockRestore()
+    }
+  })
+})

--- a/packages/core/src/worklet/transfer/sender.ts
+++ b/packages/core/src/worklet/transfer/sender.ts
@@ -141,7 +141,7 @@ export class TransferSender {
 
     return files.map((file) => {
       const id = createFileId()
-      this.sourcePaths.set(id, file.inputPath)
+      if (!file.alreadyStaged) this.sourcePaths.set(id, file.inputPath)
       if (file.isTemporary) this.temporaryPaths.add(file.inputPath)
       return {
         id,
@@ -171,14 +171,20 @@ export class TransferSender {
     signal?: AbortSignal
   ): Promise<void> {
     const files = this.pendingStage
+    const superseded = () => this.pendingStage !== files
 
-    for (const file of files) {
-      if (signal?.aborted) throw new AbortError()
-      onStaging(file)
-      if (!file.alreadyStaged) await this.importToDrive(file.sourceDrive, file.sourcePath)
+    try {
+      for (const file of files) {
+        if (signal?.aborted) throw new AbortError()
+        onStaging(file)
+        if (!file.alreadyStaged) await this.importToDrive(file.sourceDrive, file.sourcePath)
+      }
+    } catch (err) {
+      if (superseded()) return
+      throw err
     }
 
-    if (this.pendingStage !== files) return
+    if (superseded()) return
     this.pendingStage = []
     await this.closeSourceDrives()
   }

--- a/packages/core/src/worklet/transfer/sender.ts
+++ b/packages/core/src/worklet/transfer/sender.ts
@@ -46,23 +46,20 @@ function resolveSource(
   return { root: getDirname(path), relativePath: fileName }
 }
 
-/**
- * TransferSender handles the **sender** side of a file transfer.
- *
- * Responsibilities:
- *   - Scanning local file paths to gather metadata (size, name) without
- *     modifying any shared state — so transfer-start can be announced first
- *   - Importing scanned files into the shared Hyperdrive one by one
- *   - Building TransferStart / TransferReady control messages
- *
- * It has no knowledge of Hyperswarm, peer sessions, or disk download logic.
- */
 export class TransferSender {
   private readonly drive: Hyperdrive
   private readonly scanDrives: Set<Localdrive> = new Set()
+  private readonly sourcePaths = new Map<string, string>()
+  private readonly temporaryPaths = new Set<string>()
+  private pendingStage: ScannedFile[] = []
+  private staging: Promise<void> | null = null
 
   constructor(drive: Hyperdrive) {
     this.drive = drive
+  }
+
+  localPath(fileId: string): string | null {
+    return this.sourcePaths.get(fileId) ?? null
   }
 
   get driveKey(): string {
@@ -139,35 +136,64 @@ export class TransferSender {
     }
   }
 
-  async stageFiles(
-    files: ScannedFile[],
-    transferId: string,
-    onStaging: (file: ScannedFile) => void,
-    signal?: AbortSignal
-  ): Promise<FileOffer[]> {
-    const offers: FileOffer[] = []
+  buildOffers(files: ScannedFile[], transferId: string): FileOffer[] {
+    this.pendingStage = files
 
-    for (const file of files) {
-      if (signal?.aborted) throw new AbortError()
-      onStaging(file)
-      if (!file.alreadyStaged) {
-        await this.importToDrive(file.sourceDrive, file.sourcePath)
-        if (file.isTemporary) {
-          await this.tryDeleteFile(file.inputPath)
-        }
-      }
-      offers.push({
-        id: createFileId(),
+    return files.map((file) => {
+      const id = createFileId()
+      this.sourcePaths.set(id, file.inputPath)
+      if (file.isTemporary) this.temporaryPaths.add(file.inputPath)
+      return {
+        id,
         transferId,
         name: file.fileName,
         path: file.sourcePath,
         size: file.size,
         driveKey: this.driveKey,
         kind: 'file'
+      }
+    })
+  }
+
+  stageForLegacyPeers(onStaging: (file: ScannedFile) => void, signal?: AbortSignal): Promise<void> {
+    if (!this.staging) {
+      const run: Promise<void> = this.runStaging(onStaging, signal).catch((err) => {
+        if (this.staging === run) this.staging = null
+        throw err
       })
+      this.staging = run
+    }
+    return this.staging
+  }
+
+  private async runStaging(
+    onStaging: (file: ScannedFile) => void,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const files = this.pendingStage
+
+    for (const file of files) {
+      if (signal?.aborted) throw new AbortError()
+      onStaging(file)
+      if (!file.alreadyStaged) await this.importToDrive(file.sourceDrive, file.sourcePath)
     }
 
-    return offers
+    if (this.pendingStage !== files) return
+    this.pendingStage = []
+    await this.closeSourceDrives()
+  }
+
+  async reset(): Promise<void> {
+    this.sourcePaths.clear()
+    this.pendingStage = []
+    this.staging = null
+    await this.closeSourceDrives()
+
+    const temporaries = Array.from(this.temporaryPaths)
+    this.temporaryPaths.clear()
+    for (const path of temporaries) {
+      await this.tryDeleteFile(path)
+    }
   }
 
   private async importToDrive(sourceDrive: Localdrive, sourcePath: string): Promise<void> {

--- a/packages/core/src/worklet/transfer/swarm.ts
+++ b/packages/core/src/worklet/transfer/swarm.ts
@@ -4,6 +4,7 @@ import Hyperswarm, { type PeerInfo, type PeerSocket } from 'hyperswarm'
 import { PeerControlChannel } from './control-channel'
 import type { PeerControlMessage } from './control-channel'
 import { PeerIdentityStore, type NoiseKeyPair } from './peer-identity-store'
+import { PeerDrive } from './drive'
 import { relayThrough, isRelayHost } from '../relay/config'
 
 type ConnectionType = 'direct' | 'relay'
@@ -13,6 +14,7 @@ export interface PeerSession {
   peerKey: string
   controlChannel: PeerControlChannel
   handshakeHash: Uint8Array | null
+  drive: PeerDrive | null
 }
 
 export interface TransferSwarmCallbacks {
@@ -26,28 +28,21 @@ export interface TransferSwarmCallbacks {
 
 export interface TransferSwarmOptions {
   identityStore?: PeerIdentityStore
+  drive?: boolean
 }
 
-/**
- * TransferSwarm manages Hyperswarm connectivity.
- *
- * Responsibilities:
- *   - Joining / leaving discovery topics
- *   - Tracking active peer sessions
- *   - Creating per-socket Protomux control channels
- *   - Broadcasting control messages to all connected peers
- *
- */
 export class TransferSwarm {
   private swarm: Hyperswarm | null
   private readonly peerSessions: Map<PeerSocket, PeerSession>
   private readonly callbacks: TransferSwarmCallbacks
   private readonly identityStore: PeerIdentityStore | null
+  private readonly driveEnabled: boolean
   private hostedTopicHex: string | null
   private joinedAny: boolean
 
   constructor(callbacks: TransferSwarmCallbacks, options: TransferSwarmOptions = {}) {
     this.identityStore = options.identityStore ?? null
+    this.driveEnabled = options.drive ?? false
     this.callbacks = callbacks
     this.peerSessions = new Map()
     this.hostedTopicHex = null
@@ -105,7 +100,13 @@ export class TransferSwarm {
       return
     }
 
-    session = { socket, peerKey, controlChannel, handshakeHash: socket.handshakeHash ?? null }
+    session = {
+      socket,
+      peerKey,
+      controlChannel,
+      handshakeHash: socket.handshakeHash ?? null,
+      drive: this.driveEnabled ? PeerDrive.create(socket) : null
+    }
     this.peerSessions.set(socket, session)
     this.callbacks.onPeerConnected(session)
     this.classifyConnection(socket, peerKey)
@@ -143,6 +144,7 @@ export class TransferSwarm {
     const session = this.peerSessions.get(socket)
     if (!session) return
     this.peerSessions.delete(socket)
+    session.drive?.destroy()
     this.callbacks.onPeerDisconnected(session.peerKey, this.peerSessions.size)
   }
 
@@ -156,7 +158,8 @@ export class TransferSwarm {
     this.hostedTopicHex = null
     this.joinedAny = false
 
-    for (const conn of this.peerSessions.keys()) {
+    for (const [conn, session] of this.peerSessions) {
+      session.drive?.destroy()
       try {
         conn.destroy()
       } catch {}
@@ -212,20 +215,23 @@ export class TransferSwarm {
     }
   }
 
-  sendTo(peerKey: string, message: PeerControlMessage): void {
+  get sessions(): PeerSession[] {
+    return Array.from(this.peerSessions.values())
+  }
+
+  getSession(peerKey: string): PeerSession | null {
     for (const session of this.peerSessions.values()) {
-      if (session.peerKey === peerKey) {
-        session.controlChannel.send(message)
-        return
-      }
+      if (session.peerKey === peerKey) return session
     }
+    return null
+  }
+
+  sendTo(peerKey: string, message: PeerControlMessage): void {
+    this.getSession(peerKey)?.controlChannel.send(message)
   }
 
   getHandshakeHash(peerKey: string): Uint8Array | null {
-    for (const session of this.peerSessions.values()) {
-      if (session.peerKey === peerKey) return session.handshakeHash
-    }
-    return null
+    return this.getSession(peerKey)?.handshakeHash ?? null
   }
 
   get peerCount(): number {

--- a/packages/core/src/worklet/transfer/utils.ts
+++ b/packages/core/src/worklet/transfer/utils.ts
@@ -73,3 +73,13 @@ export class AbortError extends Error {
     this.name = 'AbortError'
   }
 }
+
+export function onAbort(signal: AbortSignal | undefined, abort: () => void): () => void {
+  if (!signal) return () => {}
+  if (signal.aborted) {
+    abort()
+    return () => {}
+  }
+  signal.addEventListener('abort', abort)
+  return () => signal.removeEventListener('abort', abort)
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      'bare-fs': 'node:fs'
+    }
+  }
+})

--- a/packages/drive/README.md
+++ b/packages/drive/README.md
@@ -1,24 +1,10 @@
 # @altersend/drive
 
 Chunked file transfer over a caller-supplied channel. The sender reads byte
-ranges from the source file (`pread`) and the receiver writes them to their
-offsets in the destination (`pwrite`). Neither side makes an intermediate copy.
+ranges from the source, the receiver writes them to offsets in the
+destination. Neither side makes an intermediate copy.
 
 ## Usage
-
-```ts
-import { Drive } from '@altersend/drive'
-
-const drive = new Drive(receiveDir)
-const savedTo = await drive.receive('photo.jpg', channelB)
-await drive.send(filePath, channelA)
-```
-
-`receive` takes a name and saves it under the configured directory. `send` takes
-a full path to any file on disk — the directory says where files arrive, not
-where they may be sent from.
-
-If the destination varies per transfer, skip `Drive` and pass full paths:
 
 ```ts
 import { sendFile, receiveFile } from '@altersend/drive'
@@ -27,21 +13,14 @@ const savedTo = await receiveFile(destPath, channelB)
 await sendFile(srcPath, channelA)
 ```
 
+`Drive(receiveDir)` wraps these when one directory is reused: `drive.receive(name)`
+saves under it, `drive.send(path)` sends any file on disk.
+
 `transferId` is optional — the sender generates one, the receiver adopts it. Pass
-one explicitly when a channel carries several transfers at once.
+one when a channel carries several transfers.
 
-For a non-disk source, drive the sessions with your own reader/writer:
-
-```ts
-import { SenderSession, ReceiverSession, DiskReader, DiskWriter } from '@altersend/drive'
-
-const receiver = new ReceiverSession(new DiskWriter(destPath), channelB, { transferId })
-const savedTo = await receiver.receive()
-
-const sender = new SenderSession(new DiskReader(srcPath), channelA, { transferId, name })
-await sender.start()
-await sender.close()
-```
+For a non-disk source, pass your own reader/writer to `SenderSession` /
+`ReceiverSession`.
 
 ## Protocol
 
@@ -49,25 +28,26 @@ await sender.close()
 start    { transferId, name, size, chunkSize }   sender → receiver
 need     { indices }                              receiver → sender
 <chunk>  header{ index, hash } + bytes            sender → receiver
-complete { fileHash | null }                      sender → receiver
+complete { fileHash }                             sender → receiver
 ack      { savedTo }                              receiver → sender
 cancel   { reason? }                              either
 ```
 
-Chunk size is a pure function of file size, so both sides derive the same
-geometry from `start` alone. Each chunk carries a blake2b hash, verified on
-arrival. `fileHash` is a hash over the chunk hashes.
+Chunk size is derived from file size, so both sides compute the same geometry
+from `start`. Each chunk carries a blake2b hash, verified on arrival. `fileHash`
+hashes the chunk hashes; the receiver checks it on resume.
 
 ## Interfaces
 
-The engine imports no filesystem or socket. It drives three interfaces:
+The engine imports no filesystem or socket:
 
-| Interface      | Native           | Browser (not built)           |
-| -------------- | ---------------- | ----------------------------- |
-| `ChunkReader`  | `bare-fs` pread  | `File.slice().arrayBuffer()`  |
-| `ChunkWriter`  | `bare-fs` pwrite | File System Access API / OPFS |
-| `DriveChannel` | Protomux on UDX  | WebSocket                     |
+| Interface      | Native          | Browser (not built)           |
+| -------------- | --------------- | ----------------------------- |
+| `ChunkReader`  | pread           | `File.slice().arrayBuffer()`  |
+| `ChunkWriter`  | pwrite          | File System Access API / OPFS |
+| `DriveChannel` | Protomux on UDX | WebSocket                     |
 
-This build ships `DiskReader` / `DiskWriter` on `node:fs`; `bare-fs` has the same
-`FileHandle` API, so the worklet swaps the import. The root export resolves to an
-fs-free build under a browser condition.
+Ships `DiskReader` / `DiskWriter`. They import `#fs` and `#path`, which the
+`imports` map resolves to `bare-fs` / `bare-path` under Bare and the Node
+builtins elsewhere, so the same adapter runs in the worklet and in tests. The
+root export resolves to an fs-free build under a browser condition.

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -5,6 +5,16 @@
   "main": "./dist/native.js",
   "types": "./dist/native.d.ts",
   "browser": "./dist/index.js",
+  "imports": {
+    "#fs": {
+      "bare": "bare-fs/promises",
+      "default": "fs/promises"
+    },
+    "#path": {
+      "bare": "bare-path",
+      "default": "path"
+    }
+  },
   "exports": {
     ".": {
       "browser": {
@@ -32,6 +42,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "bare-fs": "^4.7.0",
+    "bare-path": "^3.0.0",
     "blake2b": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/drive/src/adapters/disk-reader.ts
+++ b/packages/drive/src/adapters/disk-reader.ts
@@ -1,4 +1,5 @@
-import { open, stat, type FileHandle } from 'node:fs/promises'
+import fs from '#fs'
+import type { FileHandle } from 'node:fs/promises'
 import type { ChunkReader } from '../engine/types'
 import { readRange } from './read-range'
 
@@ -11,12 +12,12 @@ export class DiskReader implements ChunkReader {
   }
 
   private handle(): Promise<FileHandle> {
-    if (!this.opening) this.opening = open(this.path, 'r')
+    if (!this.opening) this.opening = fs.open(this.path, 'r')
     return this.opening
   }
 
   async size(): Promise<number> {
-    return (await stat(this.path)).size
+    return (await fs.stat(this.path)).size
   }
 
   async read(offset: number, length: number): Promise<Uint8Array> {

--- a/packages/drive/src/adapters/disk-writer.ts
+++ b/packages/drive/src/adapters/disk-writer.ts
@@ -1,4 +1,5 @@
-import { open, rename, unlink, type FileHandle } from 'node:fs/promises'
+import fs from '#fs'
+import type { FileHandle } from 'node:fs/promises'
 import type { ChunkWriter } from '../engine/types'
 import { readRange } from './read-range'
 
@@ -14,10 +15,10 @@ export class DiskWriter implements ChunkWriter {
 
   async allocate(size: number): Promise<void> {
     try {
-      this.handle = await open(this.partPath, 'r+')
+      this.handle = await fs.open(this.partPath, 'r+')
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
-      this.handle = await open(this.partPath, 'w+')
+      this.handle = await fs.open(this.partPath, 'w+')
     }
     await this.handle.truncate(size)
   }
@@ -37,7 +38,7 @@ export class DiskWriter implements ChunkWriter {
       await this.handle.close()
       this.handle = null
     }
-    await rename(this.partPath, this.targetPath)
+    await fs.rename(this.partPath, this.targetPath)
     return this.targetPath
   }
 
@@ -47,7 +48,7 @@ export class DiskWriter implements ChunkWriter {
       this.handle = null
     }
     try {
-      await unlink(this.partPath)
+      await fs.unlink(this.partPath)
     } catch {}
   }
 }

--- a/packages/drive/src/api/drive.ts
+++ b/packages/drive/src/api/drive.ts
@@ -1,4 +1,4 @@
-import { basename, join } from 'node:path'
+import nodePath from '#path'
 import type { DriveChannel } from '../engine/types'
 import type { Bitmap } from '../engine/bitmap'
 import { SenderSession } from '../engine/sender'
@@ -6,9 +6,22 @@ import { ReceiverSession } from '../engine/receiver'
 import { DiskReader } from '../adapters/disk-reader'
 import { DiskWriter } from '../adapters/disk-writer'
 
+const { basename, join } = nodePath
+
+function onAbort(signal: AbortSignal | undefined, cancel: () => void): () => void {
+  if (!signal) return () => {}
+  if (signal.aborted) {
+    cancel()
+    return () => {}
+  }
+  signal.addEventListener('abort', cancel)
+  return () => signal.removeEventListener('abort', cancel)
+}
+
 export interface SendFileOptions {
   transferId?: string
   name?: string
+  signal?: AbortSignal
   highWaterMark?: number
   onProgress?: (sentBytes: number, totalBytes: number) => void
 }
@@ -25,15 +38,19 @@ export async function sendFile(
     highWaterMark: opts.highWaterMark,
     onProgress: opts.onProgress
   })
+  const release = onAbort(opts.signal, () => sender.cancel())
   try {
     return await sender.start()
   } finally {
+    release()
     await reader.close()
   }
 }
 
 export interface ReceiveFileOptions {
   transferId?: string
+  expectedSize?: number
+  signal?: AbortSignal
   resumeBits?: Uint8Array
   verifyFullFile?: boolean
   onProgress?: (receivedBytes: number, totalBytes: number) => void
@@ -48,12 +65,14 @@ export function receiveFile(
   const writer = new DiskWriter(targetPath)
   const receiver = new ReceiverSession(writer, channel, {
     transferId: opts.transferId,
+    expectedSize: opts.expectedSize,
     resumeBits: opts.resumeBits,
     verifyFullFile: opts.verifyFullFile,
     onProgress: opts.onProgress,
     onChunkWritten: opts.onChunkWritten
   })
-  return receiver.receive()
+  const release = onAbort(opts.signal, () => receiver.cancel())
+  return receiver.receive().finally(release)
 }
 
 export class Drive {

--- a/packages/drive/src/engine/receiver.ts
+++ b/packages/drive/src/engine/receiver.ts
@@ -5,6 +5,7 @@ import { Bitmap } from './bitmap'
 
 export interface ReceiverOptions {
   transferId?: string
+  expectedSize?: number
   resumeBits?: Uint8Array
   verifyFullFile?: boolean
   onProgress?: (receivedBytes: number, totalBytes: number) => void
@@ -35,6 +36,7 @@ export class ReceiverSession {
     this.done = new Promise<string>((resolve, reject) => {
       this.settle = { resolve, reject }
     })
+    this.done.catch(() => {})
     this.channel.onMessage((message) => this.onMessage(message))
     this.channel.onChunk((header, data) => this.enqueue(() => this.onChunk(header, data)))
   }
@@ -79,6 +81,10 @@ export class ReceiverSession {
     if (this.settled) return
     if (!this.validGeometry(size, chunkSize)) {
       throw new Error(`Rejected transfer geometry: size=${size} chunkSize=${chunkSize}`)
+    }
+    const expected = this.opts.expectedSize
+    if (expected !== undefined && size !== expected) {
+      throw new Error(`Sender announced ${size} bytes, expected ${expected}`)
     }
     this.size = size
     this.chunkSize = chunkSize
@@ -156,6 +162,10 @@ export class ReceiverSession {
       root.add(hashChunk(bytes))
     }
     if (root.digest() !== expected) throw new Error('Full-file hash mismatch')
+  }
+
+  cancel(reason = 'Transfer cancelled'): void {
+    this.enqueue(() => this.fail(new Error(reason)))
   }
 
   private async fail(err: Error, notifyPeer = true): Promise<void> {

--- a/packages/drive/src/engine/sender.ts
+++ b/packages/drive/src/engine/sender.ts
@@ -45,17 +45,21 @@ export class SenderSession {
     if (this.started) throw new Error('SenderSession already started')
     this.started = true
 
-    this.size = await this.reader.size()
-    this.chunkSize = selectChunkSize(this.size)
-    this.totalChunks = chunkCount(this.size, this.chunkSize)
+    try {
+      this.size = await this.reader.size()
+      this.chunkSize = selectChunkSize(this.size)
+      this.totalChunks = chunkCount(this.size, this.chunkSize)
 
-    this.channel.send({
-      type: 'start',
-      transferId: this.opts.transferId,
-      name: this.opts.name,
-      size: this.size,
-      chunkSize: this.chunkSize
-    })
+      this.channel.send({
+        type: 'start',
+        transferId: this.opts.transferId,
+        name: this.opts.name,
+        size: this.size,
+        chunkSize: this.chunkSize
+      })
+    } catch (err) {
+      this.fail(err instanceof Error ? err : new Error(String(err)))
+    }
 
     return this.done
   }

--- a/packages/drive/src/engine/sender.ts
+++ b/packages/drive/src/engine/sender.ts
@@ -37,6 +37,7 @@ export class SenderSession {
     this.done = new Promise<string>((resolve, reject) => {
       this.settle = { resolve, reject }
     })
+    this.done.catch(() => {})
     this.channel.onMessage((message) => this.onMessage(message))
   }
 
@@ -100,6 +101,7 @@ export class SenderSession {
 
     let sentBytes = 0
     for (const index of indices) {
+      if (this.settled) return
       const { offset, length } = chunkRange(index, this.size, this.chunkSize)
       const data = await this.reader.read(offset, length)
       const hash = hashChunk(data)
@@ -112,7 +114,9 @@ export class SenderSession {
       this.opts.onProgress?.(sentBytes, this.size)
     }
 
+    if (this.settled) return
     const fileHash = root ? root.digest() : await this.fileRoot()
+    if (this.settled) return
     this.channel.send({
       type: 'complete',
       transferId: this.opts.transferId,
@@ -130,9 +134,13 @@ export class SenderSession {
   }
 
   private async drain(): Promise<void> {
-    while (this.channel.bufferedAmount() > this.highWater) {
+    while (!this.settled && this.channel.bufferedAmount() > this.highWater) {
       await new Promise((resolve) => setTimeout(resolve, 1))
     }
+  }
+
+  cancel(reason = 'Transfer cancelled'): void {
+    this.fail(new Error(reason))
   }
 
   private fail(err: Error, notifyPeer = true): void {

--- a/packages/drive/src/runtime.d.ts
+++ b/packages/drive/src/runtime.d.ts
@@ -1,0 +1,9 @@
+declare module '#fs' {
+  import fs from 'node:fs/promises'
+  export default fs
+}
+
+declare module '#path' {
+  import path from 'node:path'
+  export default path
+}

--- a/packages/drive/test/transfer.test.ts
+++ b/packages/drive/test/transfer.test.ts
@@ -42,3 +42,86 @@ describe('end-to-end transfer', () => {
     await expect(stat(`${dst}.part`)).rejects.toThrow()
   })
 })
+
+describe('expectedSize', () => {
+  it('rejects a sender that announces a different size than offered', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'drive-size-'))
+    const src = join(dir, 'input.bin')
+    const dst = join(dir, 'output.bin')
+    await writeFile(src, new Uint8Array(4096))
+
+    const [senderChannel, receiverChannel] = createChannelPair()
+    const receiver = new ReceiverSession(new DiskWriter(dst), receiverChannel, {
+      transferId: 's1',
+      expectedSize: 9999
+    })
+    const sender = new SenderSession(new DiskReader(src), senderChannel, {
+      transferId: 's1',
+      name: 'output.bin'
+    })
+
+    const results = await Promise.allSettled([receiver.receive(), sender.start()])
+    await sender.close()
+
+    expect(results[0].status).toBe('rejected')
+    expect((results[0] as PromiseRejectedResult).reason.message).toContain('expected 9999')
+    await expect(stat(dst)).rejects.toThrow()
+  })
+})
+
+describe('cancel', () => {
+  it('stops the sender mid-flight and leaves no partial file behind', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'drive-cancel-'))
+    const src = join(dir, 'input.bin')
+    const dst = join(dir, 'output.bin')
+    await writeFile(src, new Uint8Array(4 * 1024 * 1024))
+
+    const [senderChannel, receiverChannel] = createChannelPair()
+    const receiver = new ReceiverSession(new DiskWriter(dst), receiverChannel, { transferId: 'c1' })
+    const sender = new SenderSession(new DiskReader(src), senderChannel, {
+      transferId: 'c1',
+      name: 'output.bin'
+    })
+
+    const sent: number[] = []
+    const originalSendChunk = senderChannel.sendChunk.bind(senderChannel)
+    senderChannel.sendChunk = (header, data) => {
+      sent.push(header.index)
+      if (sent.length === 2) receiver.cancel('user cancelled')
+      originalSendChunk(header, data)
+    }
+
+    const results = await Promise.allSettled([receiver.receive(), sender.start()])
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    await sender.close()
+
+    expect(results[0].status).toBe('rejected')
+    expect(results[1].status).toBe('rejected')
+    expect(sent.length).toBeLessThan(16)
+    await expect(stat(dst)).rejects.toThrow()
+    await expect(stat(`${dst}.part`)).rejects.toThrow()
+  })
+
+  it('rejects the sender when the receiver cancels', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'drive-cancel2-'))
+    const src = join(dir, 'input.bin')
+    await writeFile(src, new Uint8Array(64))
+
+    const [senderChannel, receiverChannel] = createChannelPair()
+    const receiver = new ReceiverSession(new DiskWriter(join(dir, 'out.bin')), receiverChannel, {
+      transferId: 'c2'
+    })
+    const sender = new SenderSession(new DiskReader(src), senderChannel, {
+      transferId: 'c2',
+      name: 'out.bin'
+    })
+
+    receiver.cancel('nope')
+    const results = await Promise.allSettled([receiver.receive(), sender.start()])
+    await sender.close()
+
+    expect(results[0].status).toBe('rejected')
+    expect(results[1].status).toBe('rejected')
+    await expect(stat(join(dir, 'out.bin'))).rejects.toThrow()
+  })
+})

--- a/packages/drive/test/transfer.test.ts
+++ b/packages/drive/test/transfer.test.ts
@@ -125,3 +125,23 @@ describe('cancel', () => {
     await expect(stat(join(dir, 'out.bin'))).rejects.toThrow()
   })
 })
+
+describe('unreadable source', () => {
+  it('cancels the receiver instead of leaving it waiting', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'drive-missing-'))
+    const dst = join(dir, 'out.bin')
+
+    const [senderChannel, receiverChannel] = createChannelPair()
+    const receiver = new ReceiverSession(new DiskWriter(dst), receiverChannel, { transferId: 'm1' })
+    const sender = new SenderSession(new DiskReader(join(dir, 'gone.bin')), senderChannel, {
+      transferId: 'm1',
+      name: 'out.bin'
+    })
+
+    const results = await Promise.allSettled([receiver.receive(), sender.start()])
+
+    expect(results[1].status).toBe('rejected')
+    expect(results[0].status).toBe('rejected')
+    await expect(stat(dst)).rejects.toThrow()
+  })
+})

--- a/packages/drive/tsup.config.ts
+++ b/packages/drive/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   bundle: true,
   splitting: true,
   sourcemap: false,
+  external: ['#fs', '#path'],
   esbuildOptions(options) {
     options.packages = 'external'
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer transfers now support chunked, integrity-verified streaming with drive-based routing when available.
  * Drive API adds richer options for send/receive (progress callbacks, abort signals, expectedSize, resume/verification controls, and per-chunk hooks).
  * Receiver now supports expected-size validation and improved cancellation handling.
* **Bug Fixes**
  * Stricter transfer validation at trust boundaries and improved settled/cancel flows to reduce partial-file leftovers.
* **Documentation**
  * Updated transfer mechanics/architecture descriptions and developer Run/Build instructions; refreshed drive docs.
* **Tests**
  * Added/expanded transfer and drive end-to-end coverage (including isolation, cancel, and size-mismatch cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->