### PR TITLE
ci: automate altersend-bin AUR updates

### DIFF
--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update package version and checksums
         shell: bash

--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -1,0 +1,64 @@
+name: Update AUR package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-aur-altersend-bin
+  cancel-in-progress: false
+
+jobs:
+  update-aur:
+    if: ${{ github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update package version and checksums
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Expected a release tag in the form v1.2.3, got: $RELEASE_TAG"
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#v}"
+          release_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
+          pkgbuild="packaging/aur/PKGBUILD"
+
+          curl --fail --location --retry 3 \
+            --output "$RUNNER_TEMP/AlterSend-x86_64.AppImage" \
+            "$release_url/AlterSend-x86_64.AppImage"
+          curl --fail --location --retry 3 \
+            --output "$RUNNER_TEMP/AlterSend-arm64.AppImage" \
+            "$release_url/AlterSend-arm64.AppImage"
+
+          x86_64_checksum="$(sha256sum "$RUNNER_TEMP/AlterSend-x86_64.AppImage" | cut -d ' ' -f 1)"
+          aarch64_checksum="$(sha256sum "$RUNNER_TEMP/AlterSend-arm64.AppImage" | cut -d ' ' -f 1)"
+
+          sed -i -E "s/^pkgver=.*/pkgver=${version}/" "$pkgbuild"
+          sed -i -E "s/^pkgrel=.*/pkgrel=1/" "$pkgbuild"
+          sed -i -E \
+            "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${x86_64_checksum}')/" \
+            "$pkgbuild"
+          sed -i -E \
+            "s/^sha256sums_aarch64=.*/sha256sums_aarch64=('${aarch64_checksum}')/" \
+            "$pkgbuild"
+
+      - name: Publish altersend-bin to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
+        with:
+          pkgname: altersend-bin
+          pkgbuild: packaging/aur/PKGBUILD
+          commit_username: Reazndev
+          commit_email: ruby.florian@proton.me
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "altersend-bin: update to ${{ github.event.release.tag_name }}"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ git clone https://github.com/denislupookov/altersend.git && cd altersend
 flatpak-builder --user --install --install-deps-from=flathub --force-clean build-dir flatpak/com.altersend.AlterSend.yaml
 ```
 
+### Arch Linux
+
+AlterSend is available in the AUR as two packages: `altersend-bin` for official release binaries and `altersend-git` for the latest Git changes compiled from source.
+
+```sh
+yay -S altersend-bin
+yay -S altersend-git
+```
+
 ## How it works
 
 1. Open AlterSend on both devices

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Reazndev <ruby.florian@proton.me>
+
+pkgname=altersend-bin
+pkgver=1.7.0
+pkgrel=1
+pkgdesc='Private peer-to-peer file transfer application (prebuilt binary)'
+arch=('x86_64' 'aarch64')
+url='https://altersend.com/'
+license=('Apache-2.0')
+depends=('gtk3' 'libnotify' 'libsecret' 'libxss' 'nss')
+provides=('altersend')
+conflicts=('altersend' 'altersend-git')
+options=('!strip')
+source_x86_64=("AlterSend-x86_64.AppImage::https://github.com/denislupookov/altersend/releases/download/v${pkgver}/AlterSend-x86_64.AppImage")
+sha256sums_x86_64=('52d7245103f8a8f2e05ed6b62a39d19303c68bf45d6aadb07bc7abb2b77c23e4')
+source_aarch64=("AlterSend-arm64.AppImage::https://github.com/denislupookov/altersend/releases/download/v${pkgver}/AlterSend-arm64.AppImage")
+sha256sums_aarch64=('526d17c8fd58fac6dbb7da12524ca544aba5419ec1b3b5f73fcc0b2342c0aa26')
+
+prepare() {
+  cd "$srcdir"
+
+  local appimage
+  case "$CARCH" in
+    x86_64) appimage=AlterSend-x86_64.AppImage ;;
+    aarch64) appimage=AlterSend-arm64.AppImage ;;
+  esac
+
+  chmod +x "$appimage"
+  "./$appimage" --appimage-extract
+}
+
+package() {
+  cd "$srcdir"
+
+  install -d "$pkgdir/opt/altersend"
+  cp -a --no-preserve=ownership squashfs-root/. "$pkgdir/opt/altersend/"
+
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/altersend" <<'EOF'
+#!/bin/sh
+exec /opt/altersend/AppRun "$@"
+EOF
+
+  install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/altersend.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=AlterSend
+Comment=Private peer-to-peer file transfer
+Exec=altersend
+Icon=altersend
+Categories=Network;FileTransfer;
+StartupNotify=true
+Terminal=false
+StartupWMClass=altersend
+EOF
+
+  install -Dm644 squashfs-root/altersend.png \
+    "$pkgdir/usr/share/icons/hicolor/512x512/apps/altersend.png"
+}


### PR DESCRIPTION
## Summary

- add the maintained `altersend-bin` PKGBUILD to the upstream repository
- update its version and x86_64/ARM64 checksums when a stable GitHub Release is published
- regenerate `.SRCINFO` and publish the update to the AUR

## Why

Unlike `altersend-git`, the binary AUR package needs a new version and checksum for every release. The existing desktop release workflow creates a draft release, so this workflow waits for the release to be published before downloading its public AppImage assets.

## Repository setup

The workflow requires an `AUR_SSH_PRIVATE_KEY` repository secret whose public key is registered with the AUR account maintaining `altersend-bin` which currently is mine.

I created a separate SSH key specifically for this workflow. I will need to send you the private key directly so you can add it as the repository secret. Please let me know which channel works better for you:

- Discord: `reazn999`
- Email: `florian@ruu.by`

## Validation

- `actionlint` v1.7.7
- `makepkg --printsrcinfo`
- simulated version and checksum update
- verified both v1.7.0 AppImage names and SHA-256 digests against the published release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arch Linux installation support via the AUR, including two packages: official release binaries and the latest Git builds.
  * Added architecture-specific packaging for x86_64 and ARM64.
  * Added desktop launcher and application icon integration for the installed app.
* **Documentation**
  * Updated the README with an “Arch Linux” section and example `yay` install commands.
* **Chores**
  * Automatically refresh the AUR package when new non-prerelease GitHub releases are published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->