### PR TITLE
chore: update flatpak offline dependencies for v1.8 release

### DIFF
--- a/flatpak/node-modules.json
+++ b/flatpak/node-modules.json
@@ -1485,6 +1485,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@hyperswarm/dht-relay/-/dht-relay-0.4.3.tgz",
+        "sha512": "6e38819d53ad9bfbd717b44ee8218ae9f40e32685be0b32680e95b3eb36b12f7f6096cc07da9ba9255d0e0380a6f5198f3a28688d0a74a807a4e298d81aa1b6e",
+        "dest-filename": "819d53ad9bfbd717b44ee8218ae9f40e32685be0b32680e95b3eb36b12f7f6096cc07da9ba9255d0e0380a6f5198f3a28688d0a74a807a4e298d81aa1b6e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/38"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.9.1.tgz",
         "sha512": "c5bd12e72dd827005a903efb24e1811e5071769eb79870a56685c16282effbdc07f1ed39e0448a966429b56aa324ae5dbf954c50855838907831a3a907425d1b",
         "dest-filename": "12e72dd827005a903efb24e1811e5071769eb79870a56685c16282effbdc07f1ed39e0448a966429b56aa324ae5dbf954c50855838907831a3a907425d1b",
@@ -1748,6 +1755,20 @@
         "sha512": "dcd40d3600356129496ff90c1f58a574048ff475bbffb9189d1236b335896a87da4b585699b188e07f9ddfedb6686cd75cdf4827e9fe1a21557068a924fd7ca3",
         "dest-filename": "0d3600356129496ff90c1f58a574048ff475bbffb9189d1236b335896a87da4b585699b188e07f9ddfedb6686cd75cdf4827e9fe1a21557068a924fd7ca3",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/d4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+        "sha512": "4ff0681e01578ab6f410d48f06abb35f4adc8d778ce8ba3cf766b68e560992a93cdcba99c7497539fec3ce5289ea3929bccae41d29c07206f925e80bf1278891",
+        "dest-filename": "681e01578ab6f410d48f06abb35f4adc8d778ce8ba3cf766b68e560992a93cdcba99c7497539fec3ce5289ea3929bccae41d29c07206f925e80bf1278891",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/f0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+        "sha512": "218a831a24d769be859e20209d2759c2059ba26c69cbd16d62f2cab3bc0252cd9af119084c6f831463b50ccf5cafe137fd18000d1a458eb295689d73eac8ed12",
+        "dest-filename": "831a24d769be859e20209d2759c2059ba26c69cbd16d62f2cab3bc0252cd9af119084c6f831463b50ccf5cafe137fd18000d1a458eb295689d73eac8ed12",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/8a"
     },
     {
         "type": "file",
@@ -2896,6 +2917,13 @@
         "sha512": "da3f5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
         "dest-filename": "5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/3f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+        "sha512": "dbe0c425b341a0f44e3e48130cd7bcff561759cab16cde434e30125483b1f074bea484d7bac872362055e7a441d3cceea6dcf3f204f761f92aae24c157271ea6",
+        "dest-filename": "c425b341a0f44e3e48130cd7bcff561759cab16cde434e30125483b1f074bea484d7bac872362055e7a441d3cceea6dcf3f204f761f92aae24c157271ea6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/e0"
     },
     {
         "type": "file",
@@ -4593,10 +4621,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+        "sha512": "a77d9c385e6ad19aacf6e06238d2982e6e810a50a80423393bd25f7944a59d02c14f161d4cafa95be9d77e59bc52429dd9462511b633e6a122d09b9947d7244b",
+        "dest-filename": "9c385e6ad19aacf6e06238d2982e6e810a50a80423393bd25f7944a59d02c14f161d4cafa95be9d77e59bc52429dd9462511b633e6a122d09b9947d7244b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/7d"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
         "sha512": "35f27853304271018b0e542aee71f11feb6fde4c99d211d0a85e413ba27bb4d25e3f9768d6594fafc759f331e89df840bb43c701d3244a8fbca34c3183d9595b",
         "dest-filename": "7853304271018b0e542aee71f11feb6fde4c99d211d0a85e413ba27bb4d25e3f9768d6594fafc759f331e89df840bb43c701d3244a8fbca34c3183d9595b",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/f2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+        "sha512": "78b1e948afd8e2784c274ee00da033a17fd700a4bc3d26a88e69773340cce09a55d4b022e49389fe9e87fd75ab97c2fe0f3544bd5096d73def580681f684ec43",
+        "dest-filename": "e948afd8e2784c274ee00da033a17fd700a4bc3d26a88e69773340cce09a55d4b022e49389fe9e87fd75ab97c2fe0f3544bd5096d73def580681f684ec43",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/78/b1"
     },
     {
         "type": "file",
@@ -4660,6 +4702,13 @@
         "sha512": "29b5a047cc0e61100f7a4126317ad861d73b051ca19f616d93b2967cc527438de115da23584151c61851526dff38511d3dad6bd0a02f4d383d6102b9ef14ded2",
         "dest-filename": "a047cc0e61100f7a4126317ad861d73b051ca19f616d93b2967cc527438de115da23584151c61851526dff38511d3dad6bd0a02f4d383d6102b9ef14ded2",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/b5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+        "sha512": "c2f52306d48637bfbb4a3369abff4cd93837e745190f7abad881592db4404756d23250a8d5969e5be049f83d3dd1ee2120864b05c4c359ee0c8788ef5036a3cd",
+        "dest-filename": "2306d48637bfbb4a3369abff4cd93837e745190f7abad881592db4404756d23250a8d5969e5be049f83d3dd1ee2120864b05c4c359ee0c8788ef5036a3cd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/f5"
     },
     {
         "type": "file",
@@ -5132,6 +5181,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+        "sha512": "4b5930996d9985914514e821731ef7f996a311f281aa13fcd8932cb31b4b54cc6568f79ad69f6ea0b894679598c879f429d7706cb73ed2f878c11d0a04da13e7",
+        "dest-filename": "30996d9985914514e821731ef7f996a311f281aa13fcd8932cb31b4b54cc6568f79ad69f6ea0b894679598c879f429d7706cb73ed2f878c11d0a04da13e7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/59"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+        "sha512": "03206eb89348eb8808bf0c75dea8880b3e87ea1a668ef612e431a41ba8db5cc393f19dd6509dd5d57d059612284f56ffe49b47137922fb18ed32fbb59e7fadf4",
+        "dest-filename": "6eb89348eb8808bf0c75dea8880b3e87ea1a668ef612e431a41ba8db5cc393f19dd6509dd5d57d059612284f56ffe49b47137922fb18ed32fbb59e7fadf4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/03/20"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.6.1.tgz",
         "sha512": "dfc62628297f9bd35c4e4c2e7816dc188b7d671dc84ff43d36c96ebba0b91aeafa3ea7c4d3358f84fc02ce26b586b8bf834202631aea9202ed11aa160f959e49",
         "dest-filename": "2628297f9bd35c4e4c2e7816dc188b7d671dc84ff43d36c96ebba0b91aeafa3ea7c4d3358f84fc02ce26b586b8bf834202631aea9202ed11aa160f959e49",
@@ -5143,6 +5206,20 @@
         "sha512": "5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
         "dest-filename": "63e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/93"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+        "sha512": "dda460ebf2717df7c50fe3a53a3385477568efd977f68a014c5b9cc71f8c4f77610adce7dc49a250f428fbafce66e2368db5e2dd82a09a24c50600a140cc0845",
+        "dest-filename": "60ebf2717df7c50fe3a53a3385477568efd977f68a014c5b9cc71f8c4f77610adce7dc49a250f428fbafce66e2368db5e2dd82a09a24c50600a140cc0845",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dd/a4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+        "sha512": "56af3ce9e5f292e3f913a1dc292492b4fddb260ac4e889f958ac5552f27c5c6a56598b36c591d6a94c330ad1a012d05cc72779eca0450cf16851f37375a1c236",
+        "dest-filename": "3ce9e5f292e3f913a1dc292492b4fddb260ac4e889f958ac5552f27c5c6a56598b36c591d6a94c330ad1a012d05cc72779eca0450cf16851f37375a1c236",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/af"
     },
     {
         "type": "file",
@@ -5216,6 +5293,62 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+        "sha512": "70a57cb4c084a50b3884afe293bd5de8bacf3a7a64a46051d30cf1aabebc8369bf2c1d86c55610ae802330965154cd58e010a308a737bc06a6c52cce63644ffb",
+        "dest-filename": "7cb4c084a50b3884afe293bd5de8bacf3a7a64a46051d30cf1aabebc8369bf2c1d86c55610ae802330965154cd58e010a308a737bc06a6c52cce63644ffb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/a5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+        "sha512": "eec5ac42560bdab18bcb62169bc58bf0309326f60b73faa53a7b1a90369cf3b48ea02775e962ec68031d0a202ab1334721ef925df6aacb1ca8e931e85aab3c59",
+        "dest-filename": "ac42560bdab18bcb62169bc58bf0309326f60b73faa53a7b1a90369cf3b48ea02775e962ec68031d0a202ab1334721ef925df6aacb1ca8e931e85aab3c59",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/c5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+        "sha512": "fbb0875ea1aeb29527fd297968eec46b4c56180b444cf5cd4808c7a38f097cb74f59c327837dd77b8ce716f4307aa73fbb3939cd2388dc7e760989e309f6f984",
+        "dest-filename": "875ea1aeb29527fd297968eec46b4c56180b444cf5cd4808c7a38f097cb74f59c327837dd77b8ce716f4307aa73fbb3939cd2388dc7e760989e309f6f984",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/b0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+        "sha512": "b0f864cf401129b7f8ad142dda14e9007aa7e3b5f79652e45069fec442732e3c18f0b46cda9d2fee58ef239132a113bf99ec6b36e9cd1028ac66cfa0c36cf3d7",
+        "dest-filename": "64cf401129b7f8ad142dda14e9007aa7e3b5f79652e45069fec442732e3c18f0b46cda9d2fee58ef239132a113bf99ec6b36e9cd1028ac66cfa0c36cf3d7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/f8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+        "sha512": "062a0ed717f7845c33e2473a881848de27831689a9321acc9670c50b8ff4fef779328929b8073747e2d86f04c0f40e5873da6af5460fa9f7caa56d8e6eec17e4",
+        "dest-filename": "0ed717f7845c33e2473a881848de27831689a9321acc9670c50b8ff4fef779328929b8073747e2d86f04c0f40e5873da6af5460fa9f7caa56d8e6eec17e4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/2a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+        "sha512": "6018d20224ea334e1955e8bab178a086eebbf5add2a96391037a994c4a992269e5903205b4a73aa4dbada63c99f112538d0b6e61f79eb64c4cd751b0a185cc21",
+        "dest-filename": "d20224ea334e1955e8bab178a086eebbf5add2a96391037a994c4a992269e5903205b4a73aa4dbada63c99f112538d0b6e61f79eb64c4cd751b0a185cc21",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/18"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+        "sha512": "b1df90eb97e39560985ad64a5e229fad473c77ee23b69ffc7f45b6364c332eda16e1b23a5039d6bac2d622eac79e6bab5b45d2848471a7088e5f81283ed5d402",
+        "dest-filename": "90eb97e39560985ad64a5e229fad473c77ee23b69ffc7f45b6364c332eda16e1b23a5039d6bac2d622eac79e6bab5b45d2848471a7088e5f81283ed5d402",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/df"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+        "sha512": "67de36472b075e626b86a93cf0598a055abfbf9b6a992903cfba79e06fcc1b28cc9c21459c2efd5d635b83e56d6bc5ba59bdaab526534b1206909ad1a4214488",
+        "dest-filename": "36472b075e626b86a93cf0598a055abfbf9b6a992903cfba79e06fcc1b28cc9c21459c2efd5d635b83e56d6bc5ba59bdaab526534b1206909ad1a4214488",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/de"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
         "sha512": "e3cc52ae2658620fbca979daf64c2a8c8573b90c62f8a616a76fb99c262760a3d3af42ef0fcf49aa4d8eaf9a20c73d0d50c7c88e1876948517fcbc97f41e2822",
         "dest-filename": "52ae2658620fbca979daf64c2a8c8573b90c62f8a616a76fb99c262760a3d3af42ef0fcf49aa4d8eaf9a20c73d0d50c7c88e1876948517fcbc97f41e2822",
@@ -5244,6 +5377,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+        "sha512": "e7bd6cd13ee76562babc1ebb1c8e5dc9417bc1788d71f68f3cf4e5eb3602340a4036322f6094e0ee196e77ff9c269740852edd573a8c2e67e17c7477ac070e8d",
+        "dest-filename": "6cd13ee76562babc1ebb1c8e5dc9417bc1788d71f68f3cf4e5eb3602340a4036322f6094e0ee196e77ff9c269740852edd573a8c2e67e17c7477ac070e8d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/bd"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
         "sha512": "10773220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15",
         "dest-filename": "3220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15",
@@ -5262,6 +5402,13 @@
         "sha512": "a66d654d86c6c9cf740c78020ceedea3c465e04a8a2dc89ac8d6d9a86ce2aa71fd8eb94a7bc640346762b722d953ea49875e9d7f38c0c76c50abd31cb883c4b7",
         "dest-filename": "654d86c6c9cf740c78020ceedea3c465e04a8a2dc89ac8d6d9a86ce2aa71fd8eb94a7bc640346762b722d953ea49875e9d7f38c0c76c50abd31cb883c4b7",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/6d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+        "sha512": "1e9185c35f038055a59dc0df8d36b6adc4385bcf0ed660bc7bcc99d80bd06392836a4b524f0a3e2917fa9c72ba1512391724726ffe53ebe4d2c5f3fb4321ac99",
+        "dest-filename": "85c35f038055a59dc0df8d36b6adc4385bcf0ed660bc7bcc99d80bd06392836a4b524f0a3e2917fa9c72ba1512391724726ffe53ebe4d2c5f3fb4321ac99",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/91"
     },
     {
         "type": "file",
@@ -5321,6 +5468,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+        "sha512": "6bf872fa936c1544d1f88cfc4c226f5ee74a54b027cff0f2792528d74239caf143409045536b3dbaa429a12ac996ba0750aa0aab383e7a9c723fd96a15dcdf05",
+        "dest-filename": "72fa936c1544d1f88cfc4c226f5ee74a54b027cff0f2792528d74239caf143409045536b3dbaa429a12ac996ba0750aa0aab383e7a9c723fd96a15dcdf05",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/f8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+        "sha512": "fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
+        "dest-filename": "3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/2b"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
         "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
         "dest-filename": "6302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
@@ -5346,6 +5507,13 @@
         "sha512": "8552cc519160478249e800add6e1044af40dd7f74156a3c0298d2182b57bd1e377dfdd4aea3b807d38ca64b2af38cb31f0fc40ee0b18d7fb4b30c4dc7c52cba7",
         "dest-filename": "cc519160478249e800add6e1044af40dd7f74156a3c0298d2182b57bd1e377dfdd4aea3b807d38ca64b2af38cb31f0fc40ee0b18d7fb4b30c4dc7c52cba7",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/52"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chacha20-universal/-/chacha20-universal-1.0.4.tgz",
+        "sha512": "fc83b175658d6bb9d169b7deefea05fa35641a396bdb150be09f25fcebf36618fe73d46932aa28dc3abee675358ff05f95157804a9da438fb8a07d72069406d5",
+        "dest-filename": "b175658d6bb9d169b7deefea05fa35641a396bdb150be09f25fcebf36618fe73d46932aa28dc3abee675358ff05f95157804a9da438fb8a07d72069406d5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/83"
     },
     {
         "type": "file",
@@ -5465,6 +5633,13 @@
         "sha512": "59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
         "dest-filename": "b6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/dc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+        "sha512": "333f50313e5f25eedb288ecc1f7d548a54f97042b91071d109c730fd8445b11638ec0b8d81a57a1d8debb1ca74fc8e10fad4d6ff9ce8aa949e451239e1390358",
+        "dest-filename": "50313e5f25eedb288ecc1f7d548a54f97042b91071d109c730fd8445b11638ec0b8d81a57a1d8debb1ca74fc8e10fad4d6ff9ce8aa949e451239e1390358",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/33/3f"
     },
     {
         "type": "file",
@@ -5790,6 +5965,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+        "sha512": "64c9183bf2e4175ed0bc23ea334831c3cc94ce28003993925921e0f75147ea8ad2eef7048f975565389d3767d0d78c8149d83ded1aa148dc0b517227779d8e4c",
+        "dest-filename": "183bf2e4175ed0bc23ea334831c3cc94ce28003993925921e0f75147ea8ad2eef7048f975565389d3767d0d78c8149d83ded1aa148dc0b517227779d8e4c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/c9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+        "sha512": "c45c4ec2a23347f7b593580b896128a6148232a5dcc151c81fb6a47fb6ffbf1714786ba7963de1bd969aab1c07b13827f889ddb64409812ced20359eba65890d",
+        "dest-filename": "4ec2a23347f7b593580b896128a6148232a5dcc151c81fb6a47fb6ffbf1714786ba7963de1bd969aab1c07b13827f889ddb64409812ced20359eba65890d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/5c"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
         "sha512": "2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126",
         "dest-filename": "78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126",
@@ -5832,6 +6021,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+        "sha512": "99ff930b1f3059cf55a6ec5f3f686dd2248848b667b742605a5ace29988dab25195a78c868221535002b3079c264a7c461183a20cec0f8d789a0df207ff5acd0",
+        "dest-filename": "930b1f3059cf55a6ec5f3f686dd2248848b667b742605a5ace29988dab25195a78c868221535002b3079c264a7c461183a20cec0f8d789a0df207ff5acd0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/99/ff"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+        "sha512": "cf4d1b0863470c6f261c090fec2b53d6a56ef9b15050f8d8abfe08bf70b79168d3155d74cc88df4a87aa5e8f40b30b3c8304870c68ff865daee0e1888daa5e0a",
+        "dest-filename": "1b0863470c6f261c090fec2b53d6a56ef9b15050f8d8abfe08bf70b79168d3155d74cc88df4a87aa5e8f40b30b3c8304870c68ff865daee0e1888daa5e0a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/4d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+        "sha512": "3091bd962899fa881ce13cd4c2ebdb111d4945d82f505481e7e551fe0e61f367c668845631675db4a0478bbfec5617e3419e927a197286f418adc6246942292e",
+        "dest-filename": "bd962899fa881ce13cd4c2ebdb111d4945d82f505481e7e551fe0e61f367c668845631675db4a0478bbfec5617e3419e927a197286f418adc6246942292e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/91"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+        "sha512": "75c2855f78e7d0ca486978e2b2846f7b12095442b36aaef3dab64ac5ff8c4abf5391d9879ac5389b695c2e88eb8ff14797c9a4e55c4c99803e7ed4643ffde829",
+        "dest-filename": "855f78e7d0ca486978e2b2846f7b12095442b36aaef3dab64ac5ff8c4abf5391d9879ac5389b695c2e88eb8ff14797c9a4e55c4c99803e7ed4643ffde829",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/c2"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
         "sha512": "f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
         "dest-filename": "3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
@@ -5857,6 +6074,13 @@
         "sha512": "9fade2d25674aef43a15788643efc91422805323c584b418248a8a69afad489b5f29e50b17f20334301b767488c604b8353bb0d9bd3e963f0bcdf213baaf99c5",
         "dest-filename": "e2d25674aef43a15788643efc91422805323c584b418248a8a69afad489b5f29e50b17f20334301b767488c604b8353bb0d9bd3e963f0bcdf213baaf99c5",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/ad"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+        "sha512": "af8112c3f225bac0f5ee58108b53b6d056b7a8d9ec724475dba4dd52e06002eec60584883ef74dc8e35ddd9af1874c42c00e3eeb0fd30c0ac13ec32f86eafe29",
+        "dest-filename": "12c3f225bac0f5ee58108b53b6d056b7a8d9ec724475dba4dd52e06002eec60584883ef74dc8e35ddd9af1874c42c00e3eeb0fd30c0ac13ec32f86eafe29",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/af/81"
     },
     {
         "type": "file",
@@ -6070,6 +6294,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+        "sha512": "af5ec6c638540a3491cbc6a2269afcfd469d148ccccc919ec48dcd9b3e000e2f4b612171e204c1a7cd3e35a5ff62c5d658b86967bbffbffb9b11cfdb08d7cac2",
+        "dest-filename": "c6c638540a3491cbc6a2269afcfd469d148ccccc919ec48dcd9b3e000e2f4b612171e204c1a7cd3e35a5ff62c5d658b86967bbffbffb9b11cfdb08d7cac2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/af/5e"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
         "sha512": "dac246253697208691d70e22252368374867318ec6a5cfe7f03e2a482270f10a855977fb72e0209c41f1069c1e69570f7af0b69772a98d80b1dcdca941081a26",
         "dest-filename": "46253697208691d70e22252368374867318ec6a5cfe7f03e2a482270f10a855977fb72e0209c41f1069c1e69570f7af0b69772a98d80b1dcdca941081a26",
@@ -6109,6 +6340,13 @@
         "sha512": "36c7e0465143427900dbe1fe8495cc3cb9813a7fd348821cd1c44c57cab8d8ce31735b805d6b69bc8210b0e345e6d61c602ea9c746ec96b50689d78dd61e12e0",
         "dest-filename": "e0465143427900dbe1fe8495cc3cb9813a7fd348821cd1c44c57cab8d8ce31735b805d6b69bc8210b0e345e6d61c602ea9c746ec96b50689d78dd61e12e0",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/c7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+        "sha512": "92a6a0fcd97e7f71b0c8adb97e150c623f350543ab67d22e26c8c870313989c34cf452470159b755c503c5d2cfa10b53b94ca55a6e992249d8270c1a3f1b14ce",
+        "dest-filename": "a0fcd97e7f71b0c8adb97e150c623f350543ab67d22e26c8c870313989c34cf452470159b755c503c5d2cfa10b53b94ca55a6e992249d8270c1a3f1b14ce",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/a6"
     },
     {
         "type": "file",
@@ -6172,6 +6410,13 @@
         "sha512": "c08900af28aab7f9d5e4440aa90a68dd24e848e57d2740e76c9ab02bb5affd3adcf76cc801867816532ef893c55b50df185b7cd594c21a00c469b7df5de2f226",
         "dest-filename": "00af28aab7f9d5e4440aa90a68dd24e848e57d2740e76c9ab02bb5affd3adcf76cc801867816532ef893c55b50df185b7cd594c21a00c469b7df5de2f226",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/89"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
+        "sha512": "2060708c5eed364ddcc32a45347ffb6dfcc17204826da30e0f71ac698d4053f251ae71e762010cd3ef6442de76899c6336c8c1b4962d6a8d78e95f9ff2315937",
+        "dest-filename": "708c5eed364ddcc32a45347ffb6dfcc17204826da30e0f71ac698d4053f251ae71e762010cd3ef6442de76899c6336c8c1b4962d6a8d78e95f9ff2315937",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/60"
     },
     {
         "type": "file",
@@ -6312,6 +6557,13 @@
         "sha512": "7bb5d57007f25a8150192ed9860c5e367d008a31daaa04426bab80e9360eaef056bfcb2623a2482ef311ffc0d80489f4ee8aafc432d10bdd2dbbfc5ad9c242a3",
         "dest-filename": "d57007f25a8150192ed9860c5e367d008a31daaa04426bab80e9360eaef056bfcb2623a2482ef311ffc0d80489f4ee8aafc432d10bdd2dbbfc5ad9c242a3",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/b5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+        "sha512": "45a75dbef31ab4ad8b247a8527e600e16cac54de48b5af44df96e8b6a218b294384e444094289c77328e8e5cafff565ae51c93367edd8bffde115d2e4c07dede",
+        "dest-filename": "5dbef31ab4ad8b247a8527e600e16cac54de48b5af44df96e8b6a218b294384e444094289c77328e8e5cafff565ae51c93367edd8bffde115d2e4c07dede",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/a7"
     },
     {
         "type": "file",
@@ -6672,6 +6924,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+        "sha512": "fdfd86a384e88271ff2af08848fece52c1e7f39853f67524c7103d0445b1167f8e8fda3c64d2e6ff8d217658122f2b8e8a6b2b4ca2d4304a2b41ec69fda3d078",
+        "dest-filename": "86a384e88271ff2af08848fece52c1e7f39853f67524c7103d0445b1167f8e8fda3c64d2e6ff8d217658122f2b8e8a6b2b4ca2d4304a2b41ec69fda3d078",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/fd"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
         "sha512": "69d6f1732595e3aaa21f2bd2a79d132add39b41e2d2b71dc985eff9f17c07619e8c7cdec7930dbc276aa28ee2c5d1cbbae81c0205a893ff470fc0b846d7eb52c",
         "dest-filename": "f1732595e3aaa21f2bd2a79d132add39b41e2d2b71dc985eff9f17c07619e8c7cdec7930dbc276aa28ee2c5d1cbbae81c0205a893ff470fc0b846d7eb52c",
@@ -7015,6 +7274,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+        "sha512": "b5b64db89acbc06529df3b2106d772e16f8e47166e221f1ae629722044030b9ad8d5fdd4db424caf2d0b977581cd4e7c1192ac12e2455e16f9830bfc0ac3ef80",
+        "dest-filename": "4db89acbc06529df3b2106d772e16f8e47166e221f1ae629722044030b9ad8d5fdd4db424caf2d0b977581cd4e7c1192ac12e2455e16f9830bfc0ac3ef80",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/b6"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
         "sha512": "5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
         "dest-filename": "d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
@@ -7138,6 +7404,13 @@
         "sha512": "e853ef0ff215c93e1994d7bb59c9f915bff80a18a0a6e70a612bc3e9afb488ca0b9f68a7a68ef5d5ec8870a8e60ed1395cd720024487f6e37f9df01e6731c47e",
         "dest-filename": "ef0ff215c93e1994d7bb59c9f915bff80a18a0a6e70a612bc3e9afb488ca0b9f68a7a68ef5d5ec8870a8e60ed1395cd720024487f6e37f9df01e6731c47e",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/53"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+        "sha512": "74ac75d9e442548cea0b1146a65c8528930fbcb11682636d52ba53889211e6ef7bcc48511bcc92aed6e83c7657c7b75a2f1415ae5eb8ddc4f36da6f6b64423c6",
+        "dest-filename": "75d9e442548cea0b1146a65c8528930fbcb11682636d52ba53889211e6ef7bcc48511bcc92aed6e83c7657c7b75a2f1415ae5eb8ddc4f36da6f6b64423c6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/ac"
     },
     {
         "type": "file",
@@ -7285,6 +7558,13 @@
         "sha512": "21f4d8d1d299338dc00b21af5e46c6ec37bb598eccc534b954ee89ba17bca092a90a6ad8617a2aa7f70932c924a62d24f47f30b97ab41fe788f3df3f042aaf5e",
         "dest-filename": "d8d1d299338dc00b21af5e46c6ec37bb598eccc534b954ee89ba17bca092a90a6ad8617a2aa7f70932c924a62d24f47f30b97ab41fe788f3df3f042aaf5e",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/f4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+        "sha512": "485745988262fb26c2d2f8e51cdd191951877379601340f13c04f47638d583e9233a74aa725aa68f4290ef291338b3fa631a2a3afb8038319d707267fb8deade",
+        "dest-filename": "45988262fb26c2d2f8e51cdd191951877379601340f13c04f47638d583e9233a74aa725aa68f4290ef291338b3fa631a2a3afb8038319d707267fb8deade",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/48/57"
     },
     {
         "type": "file",
@@ -7463,6 +7743,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.3.tgz",
+        "sha512": "0018f4ee6987acadc50bc7c9dcf3f9402adb037d73901e10837e0d166620c099c1c737db466b4ccce839e0f2f9e4e1b9b058ef981cc3d2af39240b51940ddd48",
+        "dest-filename": "f4ee6987acadc50bc7c9dcf3f9402adb037d73901e10837e0d166620c099c1c737db466b4ccce839e0f2f9e4e1b9b058ef981cc3d2af39240b51940ddd48",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/18"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
         "sha512": "b0a25fd7e71e401af848c92f427043343b5fe135e95615466ad7aed2df75f1b977d059db1369b8bcd2d7f9559efdda6395bf87ba0198cd6eee4171fdf073c463",
         "dest-filename": "5fd7e71e401af848c92f427043343b5fe135e95615466ad7aed2df75f1b977d059db1369b8bcd2d7f9559efdda6395bf87ba0198cd6eee4171fdf073c463",
@@ -7495,6 +7782,27 @@
         "sha512": "36a00307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
         "dest-filename": "0307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/a0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+        "sha512": "bd79b4978e556dc1c45654c2cecf0cfacd15798b01da59e501a4e1a0b2865ebddb13f5560ce7a53549f27143c484a11a5c044bd931058c13b252233afb9e4a06",
+        "dest-filename": "b4978e556dc1c45654c2cecf0cfacd15798b01da59e501a4e1a0b2865ebddb13f5560ce7a53549f27143c484a11a5c044bd931058c13b252233afb9e4a06",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/79"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+        "sha512": "05bdf729ba30553223e6ceca79dd4eb2a1d4782a73fffb4fc11f84db326024aa3d6795e8959f5be9b7548239989709d68683902a84ddd53613a191a7e660183a",
+        "dest-filename": "f729ba30553223e6ceca79dd4eb2a1d4782a73fffb4fc11f84db326024aa3d6795e8959f5be9b7548239989709d68683902a84ddd53613a191a7e660183a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/bd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+        "sha512": "b5a39ab241ade33e1238034db1e3af8980ef8c42629c8911826a7b2db28fd984d3995c56065f3bb3fbb32bdafee3805c9414a9d97ecad61a9e35fcfd25b05e5c",
+        "dest-filename": "9ab241ade33e1238034db1e3af8980ef8c42629c8911826a7b2db28fd984d3995c56065f3bb3fbb32bdafee3805c9414a9d97ecad61a9e35fcfd25b05e5c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/a3"
     },
     {
         "type": "file",
@@ -7568,6 +7876,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+        "sha512": "4ed8b780ca8b7597e13906353337ff01a9cb8aa8755938898048f6e99b9843d7db90ba26cc67210b0b38172ad2778564a417e2361684d4e9fe94ecfcf788ef5e",
+        "dest-filename": "b780ca8b7597e13906353337ff01a9cb8aa8755938898048f6e99b9843d7db90ba26cc67210b0b38172ad2778564a417e2361684d4e9fe94ecfcf788ef5e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/d8"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
         "sha512": "9b120301bf4bb26e83a0e27bc47fb9f97e32d4b53fe078b9d0bf42e6c22cc0adc9cd42d2e1bc24d45be374182f611e1bcd3e2db944220b5e451367f91db2ef63",
         "dest-filename": "0301bf4bb26e83a0e27bc47fb9f97e32d4b53fe078b9d0bf42e6c22cc0adc9cd42d2e1bc24d45be374182f611e1bcd3e2db944220b5e451367f91db2ef63",
@@ -7628,6 +7943,13 @@
         "sha512": "57edb7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6",
         "dest-filename": "b7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/ed"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+        "sha512": "27e16449dc83fb4980d0dfbcd6d328b5a44c7d22fd4868bec690f74fa600a4ab1cddb1925c995f5eb8b757214e79891f2d1422b039355be8c814528179405b06",
+        "dest-filename": "6449dc83fb4980d0dfbcd6d328b5a44c7d22fd4868bec690f74fa600a4ab1cddb1925c995f5eb8b757214e79891f2d1422b039355be8c814528179405b06",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/e1"
     },
     {
         "type": "file",
@@ -7911,6 +8233,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+        "sha512": "edb55b8b486e8ffc2b2003b36fc5356acce0f64762dca37f0b2535f424c8eed028658119a0bf720835e96d737eb8fb2e5a73f4d9ccae8358257aaabe4d4f9808",
+        "dest-filename": "5b8b486e8ffc2b2003b36fc5356acce0f64762dca37f0b2535f424c8eed028658119a0bf720835e96d737eb8fb2e5a73f4d9ccae8358257aaabe4d4f9808",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/b5"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
         "sha512": "cf3d3a4bcb74a33a035cc1beb9b7b6eb37824cd5dc2883c96498bc841ac5e227422e6b38086f50b4aeea065d5ba22e4e0f31698ecc1be493e61c26cca63698ce",
         "dest-filename": "3a4bcb74a33a035cc1beb9b7b6eb37824cd5dc2883c96498bc841ac5e227422e6b38086f50b4aeea065d5ba22e4e0f31698ecc1be493e61c26cca63698ce",
@@ -7922,6 +8251,13 @@
         "sha512": "9ba52b8331555186b0181875754b164793360a5aa273d4555c2ffd7fc71e365bf621c3bd8fd27fcfc52808b3eab6c3c114dcc4a5f477c5fb6885b7ea0f1f0440",
         "dest-filename": "2b8331555186b0181875754b164793360a5aa273d4555c2ffd7fc71e365bf621c3bd8fd27fcfc52808b3eab6c3c114dcc4a5f477c5fb6885b7ea0f1f0440",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/a5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+        "sha512": "d410b40551614bfa74aadc3a7a7a7c7bef0e0f452b2b4a052f3b528cdce170a037583b89c7100f5f33ee3ed2a48c463d514a045a55fff1f80a7aed92f22f494c",
+        "dest-filename": "b40551614bfa74aadc3a7a7a7c7bef0e0f452b2b4a052f3b528cdce170a037583b89c7100f5f33ee3ed2a48c463d514a045a55fff1f80a7aed92f22f494c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/10"
     },
     {
         "type": "file",
@@ -7974,6 +8310,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+        "sha512": "ba9aadd5290690e0d6f6db06346e66b574d7b440a2cf0b52da4035eb533e8093dcd7175bfc0c7adbd69fe98ad3c1c39e4076dec2b3cd944e43c7b933bd74e2cc",
+        "dest-filename": "add5290690e0d6f6db06346e66b574d7b440a2cf0b52da4035eb533e8093dcd7175bfc0c7adbd69fe98ad3c1c39e4076dec2b3cd944e43c7b933bd74e2cc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ba/9a"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
         "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
         "dest-filename": "526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
@@ -8016,6 +8359,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+        "sha512": "13ecc12a9436b7a304a3556ca2762696e93d3711ab6f3a5e78b0b6c48562b8ed848d4db1b17b013f04ebdd892ff65d3c51811511d59e459368b9a66a17a44dd3",
+        "dest-filename": "c12a9436b7a304a3556ca2762696e93d3711ab6f3a5e78b0b6c48562b8ed848d4db1b17b013f04ebdd892ff65d3c51811511d59e459368b9a66a17a44dd3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/ec"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
         "sha512": "e350a27e483a7bc4f2952a5db53a5e2d532abd20445734edb47bc4443ef8d7ea6767c00dbf4d34e0c44be3740a3c394af5c1af369e8d6566540656c65d8c719e",
         "dest-filename": "a27e483a7bc4f2952a5db53a5e2d532abd20445734edb47bc4443ef8d7ea6767c00dbf4d34e0c44be3740a3c394af5c1af369e8d6566540656c65d8c719e",
@@ -8037,10 +8387,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+        "sha512": "32362c2873b93bb982b26446c5670b5a1785a8df4327fd939a782f8ca5e285ee9e7d588fa9cdbbe3e171ff87d88ffaf4dfe112bc17535cad15ead037ae07b3d6",
+        "dest-filename": "2c2873b93bb982b26446c5670b5a1785a8df4327fd939a782f8ca5e285ee9e7d588fa9cdbbe3e171ff87d88ffaf4dfe112bc17535cad15ead037ae07b3d6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/36"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
         "sha512": "b903e6f2472ce3b8f1dfc6ad01c593571ca5b506283d3ebccbd69661d57ac965d2c96f26cd26add132fa0a259d65e09d1772ab02fa55b671db4efe1137eaea75",
         "dest-filename": "e6f2472ce3b8f1dfc6ad01c593571ca5b506283d3ebccbd69661d57ac965d2c96f26cd26add132fa0a259d65e09d1772ab02fa55b671db4efe1137eaea75",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/03"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+        "sha512": "a7711cb227178e2b7b49ab245c7b35840f75431813c38e85bfa10528a192e434452c3f322a7a218c5de1c688eef786ff39c319a10ba4ce93e9044f6e2d52b381",
+        "dest-filename": "1cb227178e2b7b49ab245c7b35840f75431813c38e85bfa10528a192e434452c3f322a7a218c5de1c688eef786ff39c319a10ba4ce93e9044f6e2d52b381",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/71"
     },
     {
         "type": "file",
@@ -8062,6 +8426,20 @@
         "sha512": "7baaef7540a240202eba666c971449591fc3a2ae15a4f47cda4a9c96f712d1e7e0b78df44a5188934e6f742379f3e56bce0b4871f34e0e3a335627a5c9c0f84b",
         "dest-filename": "ef7540a240202eba666c971449591fc3a2ae15a4f47cda4a9c96f712d1e7e0b78df44a5188934e6f742379f3e56bce0b4871f34e0e3a335627a5c9c0f84b",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/aa"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+        "sha512": "54b82121634ce842d0ce8ef3c26720d0d99357258a623bc878cf37ca3a74c110d39949eb33aefc7d06dc281a3a9f6089105d2cce81bfff2b60f932a56bcf402d",
+        "dest-filename": "2121634ce842d0ce8ef3c26720d0d99357258a623bc878cf37ca3a74c110d39949eb33aefc7d06dc281a3a9f6089105d2cce81bfff2b60f932a56bcf402d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/b8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+        "sha512": "c478e10ebddc3412b40737542523d7667b50531fe6c0c4b9470e00ee53c9f745c600ee8848ffde3c336ea34be1a8e654f940f9268a1dc02000a1941ddc57802b",
+        "dest-filename": "e10ebddc3412b40737542523d7667b50531fe6c0c4b9470e00ee53c9f745c600ee8848ffde3c336ea34be1a8e654f940f9268a1dc02000a1941ddc57802b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/78"
     },
     {
         "type": "file",
@@ -8097,6 +8475,13 @@
         "sha512": "14552d64ca6867c46a1d2dd77971261d62c0e2d847f99c42bf694e88f227d5773b0b1aea856ccd483cc3fbf7214bfcdb61ece68b058b7500b4f497502a6b613b",
         "dest-filename": "2d64ca6867c46a1d2dd77971261d62c0e2d847f99c42bf694e88f227d5773b0b1aea856ccd483cc3fbf7214bfcdb61ece68b058b7500b4f497502a6b613b",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/55"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
+        "sha512": "bb8b1e8fd0752cf4b14c6281fc78aecef1109d71f4102624495414dfd9284b0985031865100165f51753bcbbf84ce4d0520052e4edcee5fc14c64e9bc8167e21",
+        "dest-filename": "1e8fd0752cf4b14c6281fc78aecef1109d71f4102624495414dfd9284b0985031865100165f51753bcbbf84ce4d0520052e4edcee5fc14c64e9bc8167e21",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/8b"
     },
     {
         "type": "file",
@@ -8758,6 +9143,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+        "sha512": "c62b4ff96c4d3dc4d33a09d325cae1334c6f74f7a98a93d27f723c108a4629e14b8eddcf9492c80c6deef045f9dd922e6e46fee54dbedeb10b6291211e1cdd92",
+        "dest-filename": "4ff96c4d3dc4d33a09d325cae1334c6f74f7a98a93d27f723c108a4629e14b8eddcf9492c80c6deef045f9dd922e6e46fee54dbedeb10b6291211e1cdd92",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/2b"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
         "sha512": "767eb0774bb0e46b1db303c57ec80ca79352074fda0dee9f2bde18255fc02436172fa1d52d606cc5eabb8ecec077e994d8af4b025c2993a90dd83e66c023d5a3",
         "dest-filename": "b0774bb0e46b1db303c57ec80ca79352074fda0dee9f2bde18255fc02436172fa1d52d606cc5eabb8ecec077e994d8af4b025c2993a90dd83e66c023d5a3",
@@ -8912,6 +9304,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+        "sha512": "d75e5f2e1bd956a5b01cf6c29729edc4455f5437e5f432cb4ee26fab78363bf3b18bc022368b801ef0d2cc74b4be250973e579be6ddeabdd57c2a9fd769e2344",
+        "dest-filename": "5f2e1bd956a5b01cf6c29729edc4455f5437e5f432cb4ee26fab78363bf3b18bc022368b801ef0d2cc74b4be250973e579be6ddeabdd57c2a9fd769e2344",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d7/5e"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
         "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
         "dest-filename": "38b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
@@ -8993,6 +9392,20 @@
         "sha512": "23d8f0327d3b4b2fc8c0e8f7cd59158a4d894ef8296b29036448a02fa471e8df4b6cccb0c1448cb71113fbb955a032cb7773b7217c09c2fbae9ecf1407f1de02",
         "dest-filename": "f0327d3b4b2fc8c0e8f7cd59158a4d894ef8296b29036448a02fa471e8df4b6cccb0c1448cb71113fbb955a032cb7773b7217c09c2fbae9ecf1407f1de02",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/d8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+        "sha512": "52d25c003e3211a1ad8cf7b35ae3bdc02e27c149d51fff3f226df210740fe1bebb717943fd0afd85d213094d710db4845e0d9728d68ff23b11795eef41dd34fc",
+        "dest-filename": "5c003e3211a1ad8cf7b35ae3bdc02e27c149d51fff3f226df210740fe1bebb717943fd0afd85d213094d710db4845e0d9728d68ff23b11795eef41dd34fc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/d2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+        "sha512": "2486256edea0f22e6329f277c73eeb1742d79afd93903c412d492205e67b6c0c781a79cd32bf311691a73b19fa1a14c41f1dd28d1ad912853e8f4e29ad7d64b6",
+        "dest-filename": "256edea0f22e6329f277c73eeb1742d79afd93903c412d492205e67b6c0c781a79cd32bf311691a73b19fa1a14c41f1dd28d1ad912853e8f4e29ad7d64b6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/86"
     },
     {
         "type": "file",
@@ -9339,10 +9752,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
+        "sha512": "5fbe5937c0c22dfb4633988ac2860b037ae39eb004b3decc933bd2778ab6ef8e9382983c6fc5d68811a2046e19a60700a8182d80f1d388073c64c0af66e8a40f",
+        "dest-filename": "5937c0c22dfb4633988ac2860b037ae39eb004b3decc933bd2778ab6ef8e9382983c6fc5d68811a2046e19a60700a8182d80f1d388073c64c0af66e8a40f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/be"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/noise-curve-ed/-/noise-curve-ed-2.1.0.tgz",
         "sha512": "cc0cc9c7e57064cdf0e840358539838497ef02709e0509ffd4501e6742ed1b109c0ad9402bfb895d0545fde0d550e680676f3a947971efb589faa8fd4a6b1146",
         "dest-filename": "c9c7e57064cdf0e840358539838497ef02709e0509ffd4501e6742ed1b109c0ad9402bfb895d0545fde0d550e680676f3a947971efb589faa8fd4a6b1146",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/0c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/noise-handshake/-/noise-handshake-3.1.0.tgz",
+        "sha512": "d12d6a914bcc6d3bd909f82bfef4a4553f38632bc8e10d0e2f049ce411715668da78faf103055e5de24363703b37fefeaa3f79819d792da3683fd6670571f92f",
+        "dest-filename": "6a914bcc6d3bd909f82bfef4a4553f38632bc8e10d0e2f049ce411715668da78faf103055e5de24363703b37fefeaa3f79819d792da3683fd6670571f92f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/2d"
     },
     {
         "type": "file",
@@ -9430,10 +9857,31 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+        "sha512": "5baee22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b",
+        "dest-filename": "e22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5b/ae"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+        "sha512": "17c719f8a7c69521a2d3d9494fbfcd77a28967dca0b6f602d3f51860b23d9e640a2cc9f276907dcaf6eff4ad6e4a412eec553dbd83e65702e0df6f2d5fea2ddd",
+        "dest-filename": "19f8a7c69521a2d3d9494fbfcd77a28967dca0b6f602d3f51860b23d9e640a2cc9f276907dcaf6eff4ad6e4a412eec553dbd83e65702e0df6f2d5fea2ddd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/c7"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
         "sha512": "36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
         "dest-filename": "0449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/e0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+        "sha512": "9cadbc58ea3e4088c190376e4c8344e09905fd42492b27f6109c6f24a7db943a7283443ea643873532f4430cba34fe85844fc49f357bdc1c71a9c25a5d8f5a9f",
+        "dest-filename": "bc58ea3e4088c190376e4c8344e09905fd42492b27f6109c6f24a7db943a7283443ea643873532f4430cba34fe85844fc49f357bdc1c71a9c25a5d8f5a9f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/ad"
     },
     {
         "type": "file",
@@ -9532,6 +9980,13 @@
         "sha512": "e5be98f39b4fc5967b432b4ef81433cac5b7d47264bb6edc4489646c05da371f8175c562f8b951166557cde17a6bb242c09a72c397386fe61254899022b069b9",
         "dest-filename": "98f39b4fc5967b432b4ef81433cac5b7d47264bb6edc4489646c05da371f8175c562f8b951166557cde17a6bb242c09a72c397386fe61254899022b069b9",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/be"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+        "sha512": "82372951cddc9417fdfb6d744d168359b7fead965912c859f8395731109e023a74c614eb9d0b0a1f2a48cb527777984a754ce3ebdb7bd3c107b54f0fe9b527d0",
+        "dest-filename": "2951cddc9417fdfb6d744d168359b7fead965912c859f8395731109e023a74c614eb9d0b0a1f2a48cb527777984a754ce3ebdb7bd3c107b54f0fe9b527d0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/37"
     },
     {
         "type": "file",
@@ -9654,6 +10109,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+        "sha512": "e212c1f0fcb8cd971ee6ce3277d5f3a29ab056fff218d855d4197c353982ab5efadc778adbe130553bfe95e19e2f5dc39e1db07dbaa8c153d70883b4cf8b5a63",
+        "dest-filename": "c1f0fcb8cd971ee6ce3277d5f3a29ab056fff218d855d4197c353982ab5efadc778adbe130553bfe95e19e2f5dc39e1db07dbaa8c153d70883b4cf8b5a63",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/12"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/paparam/-/paparam-1.10.1.tgz",
         "sha512": "be2c9023ae152236b465ade78c8ce1a043fc6559203e8c2164fb86d04f7a37005f609e99232aeb961586b453e474dede60b9762fc09358bfb095ad1ebe6d4a29",
         "dest-filename": "9023ae152236b465ade78c8ce1a043fc6559203e8c2164fb86d04f7a37005f609e99232aeb961586b453e474dede60b9762fc09358bfb095ad1ebe6d4a29",
@@ -9665,6 +10127,13 @@
         "sha512": "190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
         "dest-filename": "84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/0d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+        "sha512": "7c860db99fc76acb526fcd1b6863ae3d1a353bd71fe1b696c395ac029edd06e5337930ff068686f2c5537653c592c044da5176d5d37e035027ae9223496a871e",
+        "dest-filename": "0db99fc76acb526fcd1b6863ae3d1a353bd71fe1b696c395ac029edd06e5337930ff068686f2c5537653c592c044da5176d5d37e035027ae9223496a871e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7c/86"
     },
     {
         "type": "file",
@@ -9707,6 +10176,13 @@
         "sha512": "0a2c9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9",
         "dest-filename": "9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0a/2c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+        "sha512": "6fbba8d9409439865c9c5ff7203d25ba53898bf6da7f16b5c4f7bb64fb1a9a6052a634964248cdc65b7adf96064b632247d1a3bee5c2b73d9e9abde36eccfdf2",
+        "dest-filename": "a8d9409439865c9c5ff7203d25ba53898bf6da7f16b5c4f7bb64fb1a9a6052a634964248cdc65b7adf96064b632247d1a3bee5c2b73d9e9abde36eccfdf2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/bb"
     },
     {
         "type": "file",
@@ -9791,6 +10267,13 @@
         "sha512": "fff9ec8660f9e5ce3a16e170dbac55ff1140681e4717d5dd6a9ec7241067aca74077afc6c4305a340d7cef43bbf7ef6e7a0eb57192d255cf8e68595f98e6d855",
         "dest-filename": "ec8660f9e5ce3a16e170dbac55ff1140681e4717d5dd6a9ec7241067aca74077afc6c4305a340d7cef43bbf7ef6e7a0eb57192d255cf8e68595f98e6d855",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/f9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+        "sha512": "053e9e7a53c1d44c861e8f290b4a3d065ea4e9261584a3b58c46ddde5713aedafb5c77633fc056d58a5f095dc6f4ac24c606adb64f92e6adbf46fbadb42b12d6",
+        "dest-filename": "9e7a53c1d44c861e8f290b4a3d065ea4e9261584a3b58c46ddde5713aedafb5c77633fc056d58a5f095dc6f4ac24c606adb64f92e6adbf46fbadb42b12d6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/3e"
     },
     {
         "type": "file",
@@ -9913,6 +10396,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+        "sha512": "34f13c4c36f397fdd841863b0924b6dbcb37836a2595316773e422dedaa6a89a7d560da8bd4a62c5c244a361c949c376133fa411a6a5eb2ef47347a1a8904978",
+        "dest-filename": "3c4c36f397fdd841863b0924b6dbcb37836a2595316773e422dedaa6a89a7d560da8bd4a62c5c244a361c949c376133fa411a6a5eb2ef47347a1a8904978",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/34/f1"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
         "sha512": "fc99b933846fb4115590a591bb604b51334ff3f3366be530b805fe69ee3bef4ab5a951ad7e31be5930aea68662c689239878abcbcb88f9d958f0a5d85791d555",
         "dest-filename": "b933846fb4115590a591bb604b51334ff3f3366be530b805fe69ee3bef4ab5a951ad7e31be5930aea68662c689239878abcbcb88f9d958f0a5d85791d555",
@@ -9945,6 +10435,13 @@
         "sha512": "e34416e586a504d7d0a39c916268b0ed8cfa4ca295af787af7bd01d9813eddf429b1672b6e3d4fcc9831789d7d0d142384c6ca3c8b8c63cac569773c9a8a2557",
         "dest-filename": "16e586a504d7d0a39c916268b0ed8cfa4ca295af787af7bd01d9813eddf429b1672b6e3d4fcc9831789d7d0d142384c6ca3c8b8c63cac569773c9a8a2557",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/44"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+        "sha512": "ffee55153721243a158f76e1a2a8ba51eca6703d340c0c1bd672706a6ccfbc712ccc9e05a45e9234d6d46ce4bcc88e7aa87cdd57c78ad2a11f3928a87644ddc6",
+        "dest-filename": "55153721243a158f76e1a2a8ba51eca6703d340c0c1bd672706a6ccfbc712ccc9e05a45e9234d6d46ce4bcc88e7aa87cdd57c78ad2a11f3928a87644ddc6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/ee"
     },
     {
         "type": "file",
@@ -10067,6 +10564,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+        "sha512": "de8b943a9421b60adb39ad7b27bfaec4e4e92136166863fbfc0868477f80fbfd5ef6c92bcde9468bf757cc4632bdbc6e6c417a5a7db2a6c7132a22891459f56a",
+        "dest-filename": "943a9421b60adb39ad7b27bfaec4e4e92136166863fbfc0868477f80fbfd5ef6c92bcde9468bf757cc4632bdbc6e6c417a5a7db2a6c7132a22891459f56a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/8b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+        "sha512": "71d19e7ff76b585a32743d49b0ccee15ff35d349d997e193fb269c7366c471e7797fd463938cfe5ad1544c1bbd3e13a2f63fe37e604fbb498c118e3021d005f0",
+        "dest-filename": "9e7ff76b585a32743d49b0ccee15ff35d349d997e193fb269c7366c471e7797fd463938cfe5ad1544c1bbd3e13a2f63fe37e604fbb498c118e3021d005f0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/d1"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
         "sha512": "ecf887b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
         "dest-filename": "87b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
@@ -10144,10 +10655,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+        "sha512": "cd5a5af282994b3e5b4cc4c50a57357d03a7cb2133a65e68ce98b507961cbc1adda213231f6adfb01b725dcb8dbb08ec0c85e6058945d8de45949621476f6df1",
+        "dest-filename": "5af282994b3e5b4cc4c50a57357d03a7cb2133a65e68ce98b507961cbc1adda213231f6adfb01b725dcb8dbb08ec0c85e6058945d8de45949621476f6df1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/5a"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
         "sha512": "552eec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70",
         "dest-filename": "ec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/2e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+        "sha512": "8e660d1255bbcaf3bb4d5df70a34a6bd2884db2728ddb576733bbf3b30ca74c35565059fc426e55112e17fee3bb32411067b637cb75dfc7d1e82bcc81bea1a15",
+        "dest-filename": "0d1255bbcaf3bb4d5df70a34a6bd2884db2728ddb576733bbf3b30ca74c35565059fc426e55112e17fee3bb32411067b637cb75dfc7d1e82bcc81bea1a15",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8e/66"
     },
     {
         "type": "file",
@@ -10172,10 +10697,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+        "sha512": "3bd825df30a5e61e5b970d4a194cd02a1039a145d297caf0508339a344b79c25cc9624afcb90f3c7bfc325c23e4b08080aff889de499c21061d684b210703bd4",
+        "dest-filename": "25df30a5e61e5b970d4a194cd02a1039a145d297caf0508339a344b79c25cc9624afcb90f3c7bfc325c23e4b08080aff889de499c21061d684b210703bd4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/d8"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
         "sha512": "861d96621ab87e2f3e6feff62a0f421207b87c33ef1d2e77e1a38ebce65e437f957f698216c6850588f48be897700aba23d573a797e330506538dbdac830b5aa",
         "dest-filename": "96621ab87e2f3e6feff62a0f421207b87c33ef1d2e77e1a38ebce65e437f957f698216c6850588f48be897700aba23d573a797e330506538dbdac830b5aa",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/1d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+        "sha512": "efbdf1843427641305a1b122cedbfc2c897bd1c87931217f8d4415961c05c8120baaaf7a6a79a872d548633f99469d2a6c22804d39fa7afd36337afb19ae6fa8",
+        "dest-filename": "f1843427641305a1b122cedbfc2c897bd1c87931217f8d4415961c05c8120baaaf7a6a79a872d548633f99469d2a6c22804d39fa7afd36337afb19ae6fa8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/bd"
     },
     {
         "type": "file",
@@ -10256,6 +10795,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+        "sha512": "bd897788e5fee022945aec468bd5248627ba7eca97a92f4513665a89ce2d3450f637641069738c15bb8a2b84260c70b424ee81d59a78d49d0ba53d2847af1a99",
+        "dest-filename": "7788e5fee022945aec468bd5248627ba7eca97a92f4513665a89ce2d3450f637641069738c15bb8a2b84260c70b424ee81d59a78d49d0ba53d2847af1a99",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/89"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+        "sha512": "f3b95c6d1f3e321716714890fbd7be470c7c3324763fbaa7b75e729d495b9b74d4fdf8db833e06b2f7d25034de9ad082b550aa6f865c1059723cd4e1f5b0532f",
+        "dest-filename": "5c6d1f3e321716714890fbd7be470c7c3324763fbaa7b75e729d495b9b74d4fdf8db833e06b2f7d25034de9ad082b550aa6f865c1059723cd4e1f5b0532f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/b9"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
         "sha512": "1eb82cc7ea2baa8ca09e68456ca68713a736f7a27e1d30105e8c4417a80dba944e9a6189468cb37c6ddc700bdea8206bc2bff6cb143905577f1939796a03b04a",
         "dest-filename": "2cc7ea2baa8ca09e68456ca68713a736f7a27e1d30105e8c4417a80dba944e9a6189468cb37c6ddc700bdea8206bc2bff6cb143905577f1939796a03b04a",
@@ -10295,6 +10848,13 @@
         "sha512": "d29acc23e86f05b3e3b169f10cbc65086c8cf0f37a52e5a311409899984eebbc4857d5dab1afebfef0e7abe5f2ab82e8dbb83c4126cee58cc046ed03d52a6cde",
         "dest-filename": "cc23e86f05b3e3b169f10cbc65086c8cf0f37a52e5a311409899984eebbc4857d5dab1afebfef0e7abe5f2ab82e8dbb83c4126cee58cc046ed03d52a6cde",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/9a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+        "sha512": "b74051557bdb884fe8db41dfc3aebdacb6cc0835ad6192ef9898a0cb67f4331b1717eef5a71851df13a4b299ac3bc877665373ca26c09ad09ade5e2560a93a81",
+        "dest-filename": "51557bdb884fe8db41dfc3aebdacb6cc0835ad6192ef9898a0cb67f4331b1717eef5a71851df13a4b299ac3bc877665373ca26c09ad09ade5e2560a93a81",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/40"
     },
     {
         "type": "file",
@@ -10466,6 +11026,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+        "sha512": "1cd7bd5ac9536d79852bca3c726c2001e245481bedd5b3dd1c254ab5a695f96940377ea6a53e21711a706dfddf639e9aaf6a085f3b01a4e0222111c0758d0e95",
+        "dest-filename": "bd5ac9536d79852bca3c726c2001e245481bedd5b3dd1c254ab5a695f96940377ea6a53e21711a706dfddf639e9aaf6a085f3b01a4e0222111c0758d0e95",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/d7"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
         "sha512": "04d83d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
         "dest-filename": "3d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
@@ -10484,6 +11051,13 @@
         "sha512": "78520138f5bb1468f306e93785d5c4b8d4a24d94bfc443251f8f47c4ccb36f48723dfbb81215634f60c7df62b58524a656ae2c79b0169d9bae6396ae21251318",
         "dest-filename": "0138f5bb1468f306e93785d5c4b8d4a24d94bfc443251f8f47c4ccb36f48723dfbb81215634f60c7df62b58524a656ae2c79b0169d9bae6396ae21251318",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/78/52"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+        "sha512": "f29d00524e173838087b04a2d25f04a63b3e1159d688aecda03204194d07844efe67263c0f520c63ba1dbb9951ac55c683bd4bd79286f10acf9ae9b8e514ed74",
+        "dest-filename": "00524e173838087b04a2d25f04a63b3e1159d688aecda03204194d07844efe67263c0f520c63ba1dbb9951ac55c683bd4bd79286f10acf9ae9b8e514ed74",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/9d"
     },
     {
         "type": "file",
@@ -10774,6 +11348,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+        "sha512": "e438bd502d3ef21d4be990f677b6b033b13f4f8b80d5f251971eb393f36f74209512802716abc7982b8d7882a809e222c415ffabcb8cfbac9c0ef17cc28aa8b0",
+        "dest-filename": "bd502d3ef21d4be990f677b6b033b13f4f8b80d5f251971eb393f36f74209512802716abc7982b8d7882a809e222c415ffabcb8cfbac9c0ef17cc28aa8b0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/38"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
         "sha512": "08784f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
         "dest-filename": "4f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
@@ -10823,10 +11404,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+        "sha512": "19dd94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
+        "dest-filename": "94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/dd"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
         "sha512": "ae9dd2a34eca71d9a629b1af81a37141226bedb1954959394bd12ad45fa9a5b468ef4f9879a0f1930e4377c34f37e183e9b8e7626d95b8fb825e6a6e62f9825d",
         "dest-filename": "d2a34eca71d9a629b1af81a37141226bedb1954959394bd12ad45fa9a5b468ef4f9879a0f1930e4377c34f37e183e9b8e7626d95b8fb825e6a6e62f9825d",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ae/9d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+        "sha512": "c7ff82cf862b8a643141c7097f998a11b21ad4dcde091348e44725fde92695869a9a974d2cf6a557221c09934d1f732f9aa06e815e53318657bf4963b255256b",
+        "dest-filename": "82cf862b8a643141c7097f998a11b21ad4dcde091348e44725fde92695869a9a974d2cf6a557221c09934d1f732f9aa06e815e53318657bf4963b255256b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/ff"
     },
     {
         "type": "file",
@@ -10977,6 +11572,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+        "sha512": "a6045ce21278fec363582492f409a74b8d31ddb34c0d39271e02f951a3014ccc899d4f741205a1d51cfe302f5e16ee01b8dfd4c198ca42e63fd6fdeb33b1cc7e",
+        "dest-filename": "5ce21278fec363582492f409a74b8d31ddb34c0d39271e02f951a3014ccc899d4f741205a1d51cfe302f5e16ee01b8dfd4c198ca42e63fd6fdeb33b1cc7e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/04"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+        "sha512": "3004c9759a7cb0ba8397febc2df4266cff3328f2d0355e81219a0882bb1c14343e46cbcafc1c5e0d03a0cb128aa21d32ffc87706a5459c2a90fe077eade8885c",
+        "dest-filename": "c9759a7cb0ba8397febc2df4266cff3328f2d0355e81219a0882bb1c14343e46cbcafc1c5e0d03a0cb128aa21d32ffc87706a5459c2a90fe077eade8885c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/04"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
         "sha512": "1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
         "dest-filename": "c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
@@ -10988,6 +11597,41 @@
         "sha512": "4cf6de8346fbca5aecc1d1828e2f054461402aea9ba5094b6cbf123a57b78f58874ace4e6f99a1bcc03158dd9422d3a38002c0079669ddf98c7e3f266d6bd72b",
         "dest-filename": "de8346fbca5aecc1d1828e2f054461402aea9ba5094b6cbf123a57b78f58874ace4e6f99a1bcc03158dd9422d3a38002c0079669ddf98c7e3f266d6bd72b",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4c/f6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+        "sha512": "f0bcc2e7e6ef238e418e97d753c5797dd53699f78a8907b50f5808327ed752517739352ba5d2693cf1f810c0271740ec1c775266a09d4acb39a829892ae88edf",
+        "dest-filename": "c2e7e6ef238e418e97d753c5797dd53699f78a8907b50f5808327ed752517739352ba5d2693cf1f810c0271740ec1c775266a09d4acb39a829892ae88edf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/bc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz",
+        "sha512": "8219f79ae85d9f56a294242aa9c78dc5182439e65255f484d7745058483a9e307e8adb05cc655226ff8efffda1bcd5d9bb1548472373ae0b19dfb48f0dd18927",
+        "dest-filename": "f79ae85d9f56a294242aa9c78dc5182439e65255f484d7745058483a9e307e8adb05cc655226ff8efffda1bcd5d9bb1548472373ae0b19dfb48f0dd18927",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/19"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz",
+        "sha512": "a8a486011bdaa3e250945880fac8c966127feb58265bfdda34b6e5076aec808c43943c6c24f1e8f1ad6c7978f5da82adb87560252249ed010605461037be3595",
+        "dest-filename": "86011bdaa3e250945880fac8c966127feb58265bfdda34b6e5076aec808c43943c6c24f1e8f1ad6c7978f5da82adb87560252249ed010605461037be3595",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/a4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz",
+        "sha512": "91e858ba280ca119089e00afeeb860aee2c934d1c39e2b464c17647186c26e8a0bf0289d8ff6d2efc303c41c888dc73af4cf75e56c5c4138197ad67525b7904d",
+        "dest-filename": "58ba280ca119089e00afeeb860aee2c934d1c39e2b464c17647186c26e8a0bf0289d8ff6d2efc303c41c888dc73af4cf75e56c5c4138197ad67525b7904d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/e8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.4.tgz",
+        "sha512": "6a45a8c493c6081dda642ad9f9f9ba54816127fa7c89d06fec058616783f09922b428e75a1036cbc36d34915d6033222649be9cb5ea820388208fa937b6d6c2a",
+        "dest-filename": "a8c493c6081dda642ad9f9f9ba54816127fa7c89d06fec058616783f09922b428e75a1036cbc36d34915d6033222649be9cb5ea820388208fa937b6d6c2a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/45"
     },
     {
         "type": "file",
@@ -11037,6 +11681,34 @@
         "sha512": "c61761edf1f232caf49bfc369037d126e045452f7a6fd97c64f35619a43e3ccbe752767f121fa0249f4db0705decff64d37f7d5989422f3b32d7c11a31fc9a74",
         "dest-filename": "61edf1f232caf49bfc369037d126e045452f7a6fd97c64f35619a43e3ccbe752767f121fa0249f4db0705decff64d37f7d5989422f3b32d7c11a31fc9a74",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/17"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+        "sha512": "9a39ffd1b8bfa145118dce5797b21a5a2fce24926e9aea0915025f0c3c8ee3afa1056b1f69533ae53047ab67a864187397d11c8713a28e991b442f12541414d3",
+        "dest-filename": "ffd1b8bfa145118dce5797b21a5a2fce24926e9aea0915025f0c3c8ee3afa1056b1f69533ae53047ab67a864187397d11c8713a28e991b442f12541414d3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/39"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+        "sha512": "5428c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744",
+        "dest-filename": "c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+        "sha512": "58f4bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8",
+        "dest-filename": "bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/f4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+        "sha512": "eb1e9d2bacc97694f3178b1078d631c2dbc1cdfe848381ad95eb12f781cebd3b9d51ec8ad965c06887e60e0b32b2562b441785225b22e78018b05194ba19afad",
+        "dest-filename": "9d2bacc97694f3178b1078d631c2dbc1cdfe848381ad95eb12f781cebd3b9d51ec8ad965c06887e60e0b32b2562b441785225b22e78018b05194ba19afad",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/1e"
     },
     {
         "type": "file",
@@ -11107,6 +11779,13 @@
         "sha512": "6b607d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb",
         "dest-filename": "7d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/60"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz",
+        "sha512": "9a87a60b764a893cc7dbd9db168dc8c3c7db7a6596a1de2f36cfd680a6d0e78a04b3a984e9756582ec6f8a762307e526684d0f4e1832103f5f5245af8ab4fc84",
+        "dest-filename": "a60b764a893cc7dbd9db168dc8c3c7db7a6596a1de2f36cfd680a6d0e78a04b3a984e9756582ec6f8a762307e526684d0f4e1832103f5f5245af8ab4fc84",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/87"
     },
     {
         "type": "file",
@@ -11194,6 +11873,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz",
+        "sha512": "ac407347998fc4f112f948f2303bca3c85f2f48985d7b28e277da724d8bdb88aae5a94bf9df8fe87a9b4e49e722c96865e380cef62e642851b59957187fae61a",
+        "dest-filename": "7347998fc4f112f948f2303bca3c85f2f48985d7b28e277da724d8bdb88aae5a94bf9df8fe87a9b4e49e722c96865e380cef62e642851b59957187fae61a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/40"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
+        "sha512": "3a7c5294ddeec98f03d04b0b1e99a6d8738598a75d415bc4326b1a902ad753349df248e36f32f8d77b7864d1779f45314b0360c13c94be49991d37ee09e8984b",
+        "dest-filename": "5294ddeec98f03d04b0b1e99a6d8738598a75d415bc4326b1a902ad753349df248e36f32f8d77b7864d1779f45314b0360c13c94be49991d37ee09e8984b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/7c"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
         "sha512": "dd1c60c96c899614ec0013e7255a422390a84c300d653aaa16b10faabfa48df9d16818a1a55b4c504df24c5e34ba476807500f5dea0134a177333640207837f6",
         "dest-filename": "60c96c899614ec0013e7255a422390a84c300d653aaa16b10faabfa48df9d16818a1a55b4c504df24c5e34ba476807500f5dea0134a177333640207837f6",
@@ -11205,6 +11898,13 @@
         "sha512": "abf0dbada3455e6d4a7c28a266f6a99b3e540b73a5a62ad8148bc12b632119a38549bde047293c3974e2d7b508f5219fb2140d0a9b15be5a29a206f364dc96e9",
         "dest-filename": "dbada3455e6d4a7c28a266f6a99b3e540b73a5a62ad8148bc12b632119a38549bde047293c3974e2d7b508f5219fb2140d0a9b15be5a29a206f364dc96e9",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ab/f0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.1.tgz",
+        "sha512": "b0da75dcfaf160b6941474c6a032a448316fa04bb9d5b7f3135d91c0696a5357dcae4a4038ad0dbe2cda2733965743a6b64f667b6f8f9db8dc7ff97479fc6e19",
+        "dest-filename": "75dcfaf160b6941474c6a032a448316fa04bb9d5b7f3135d91c0696a5357dcae4a4038ad0dbe2cda2733965743a6b64f667b6f8f9db8dc7ff97479fc6e19",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/da"
     },
     {
         "type": "file",
@@ -11376,10 +12076,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+        "sha512": "1fbdd1007b1505aa5b8a6d2d536270c0e897523f9f8a47e26a86002871775497c0d297b6042ce48401c194b1ba444cc4fb658d65cc4e5e32bb964b28fbd7ae2c",
+        "dest-filename": "d1007b1505aa5b8a6d2d536270c0e897523f9f8a47e26a86002871775497c0d297b6042ce48401c194b1ba444cc4fb658d65cc4e5e32bb964b28fbd7ae2c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/bd"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
         "sha512": "bb240afe6c794231ee9fcd052c94df69613b26dc1f44c2812e43277bab9d60e9af1f409ac28b556bb4df8181f3027a69867e3e4f0788c7540a3274486e2a6652",
         "dest-filename": "0afe6c794231ee9fcd052c94df69613b26dc1f44c2812e43277bab9d60e9af1f409ac28b556bb4df8181f3027a69867e3e4f0788c7540a3274486e2a6652",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/24"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+        "sha512": "3aad5b2ea8ac4f22b74d2097a4f6d3e2c75e60d766c9926fd4bc69126dafbb56612bcf64484e585f065cddc5a4d0c6a019a2ab88187d98215b546b4efaf636f4",
+        "dest-filename": "5b2ea8ac4f22b74d2097a4f6d3e2c75e60d766c9926fd4bc69126dafbb56612bcf64484e585f065cddc5a4d0c6a019a2ab88187d98215b546b4efaf636f4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/ad"
     },
     {
         "type": "file",
@@ -11429,6 +12143,13 @@
         "sha512": "20868fd20de2cbd0b2cb5f30dccf5871a0ee76e8c40151cab776b7409835facaffa17f7a4db68652e6c6d212720a30814e1147fad169708ca8507527d6881a2c",
         "dest-filename": "8fd20de2cbd0b2cb5f30dccf5871a0ee76e8c40151cab776b7409835facaffa17f7a4db68652e6c6d212720a30814e1147fad169708ca8507527d6881a2c",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/86"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+        "sha512": "9ff4a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
+        "dest-filename": "a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/f4"
     },
     {
         "type": "file",
@@ -11726,6 +12447,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+        "sha512": "f69865efa0aa9ba161497f577b565400c2ed9b504b90a8f641de40a725a45f3b0c45a03b760afcd647f8c099907ff840be0f041322710e8dddbbfd0a9613e229",
+        "dest-filename": "65efa0aa9ba161497f577b565400c2ed9b504b90a8f641de40a725a45f3b0c45a03b760afcd647f8c099907ff840be0f041322710e8dddbbfd0a9613e229",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/98"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
         "sha512": "d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
         "dest-filename": "00c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
@@ -11831,6 +12559,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+        "sha512": "75bd04dd42637058690e1005e2d2e8d37a258b7a7097775b9f35ce5089512aba7e95d93f554c73a5661910db30d92662b818c7024ec37c1d1553b34a7696fab3",
+        "dest-filename": "04dd42637058690e1005e2d2e8d37a258b7a7097775b9f35ce5089512aba7e95d93f554c73a5661910db30d92662b818c7024ec37c1d1553b34a7696fab3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/bd"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
         "sha512": "d5e01db9f320ea6c209a5a23031dd078c9f307f053569ed36e7762dd4edfb5c4f6cc265a763c649262e677def399ac568beb2019c816ae8926a44a32d039f4bd",
         "dest-filename": "1db9f320ea6c209a5a23031dd078c9f307f053569ed36e7762dd4edfb5c4f6cc265a763c649262e677def399ac568beb2019c816ae8926a44a32d039f4bd",
@@ -11929,6 +12664,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+        "sha512": "0b74da3bb2bcd58be30a0407f50d52dd1dcfdc1b4ddd120cf27f8ebd7e229752b5ce013c661234a29ee40a5824c6dbad204f2142b72b1c15ef2217aa294502c7",
+        "dest-filename": "da3bb2bcd58be30a0407f50d52dd1dcfdc1b4ddd120cf27f8ebd7e229752b5ce013c661234a29ee40a5824c6dbad204f2142b72b1c15ef2217aa294502c7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/74"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
         "sha512": "5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
         "dest-filename": "94a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
@@ -11975,6 +12717,13 @@
         "sha512": "f19887166f75a2b6d201ed8f480892541564a35f296e16e207753d1a0952cc5ff3086911fabc691f1eac10c0949b89316382e30c85068027d432dc1f65f8df50",
         "dest-filename": "87166f75a2b6d201ed8f480892541564a35f296e16e207753d1a0952cc5ff3086911fabc691f1eac10c0949b89316382e30c85068027d432dc1f65f8df50",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/98"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+        "sha512": "9c0618c1f637aa7cd7df422403a01066355bb4ae9db86a27b5c426d56486d4c0fde182ea2b4e75e46340a57928c4a39632eb15b2c00758b87d49e6a879f6051b",
+        "dest-filename": "18c1f637aa7cd7df422403a01066355bb4ae9db86a27b5c426d56486d4c0fde182ea2b4e75e46340a57928c4a39632eb15b2c00758b87d49e6a879f6051b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/06"
     },
     {
         "type": "file",
@@ -12160,6 +12909,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+        "sha512": "a02c1d542ee64ee5a23f28cb533fc23b3e532e4eb0829d110ac37ec076761249de69cf70f2eb95d278dc6db89ed8c13e56cf9de9dbb0998b91dc78105ecd5f3a",
+        "dest-filename": "1d542ee64ee5a23f28cb533fc23b3e532e4eb0829d110ac37ec076761249de69cf70f2eb95d278dc6db89ed8c13e56cf9de9dbb0998b91dc78105ecd5f3a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/2c"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
         "sha512": "8d02f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
         "dest-filename": "f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
@@ -12206,6 +12962,13 @@
         "sha512": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
         "dest-filename": "f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/f0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+        "sha512": "9197ff2ba84422b58723a5ea38552288c6beefdc04fc3f10f8d08d0167259328376f877693bb344067a936388005cf9a4773753c0c872fba7a51c2d8e8b9ab9c",
+        "dest-filename": "ff2ba84422b58723a5ea38552288c6beefdc04fc3f10f8d08d0167259328376f877693bb344067a936388005cf9a4773753c0c872fba7a51c2d8e8b9ab9c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/97"
     },
     {
         "type": "file",
@@ -12272,6 +13035,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.24.0.tgz",
+        "sha512": "180f5028b1febc833c34f68603ea36b7c3c37c5525df627cad4a75cd07cc29525088d90e5f8ba7139d6d47aa6997a88ac39c8eac301d487eebfd42052c25612f",
+        "dest-filename": "5028b1febc833c34f68603ea36b7c3c37c5525df627cad4a75cd07cc29525088d90e5f8ba7139d6d47aa6997a88ac39c8eac301d487eebfd42052c25612f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/0f"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
         "sha512": "ff85c7d78ed48bb3864e38371db7567b96ab9d94126dfb91cddafd11ced3422e48ed1fa2af446573d188bc3e2fd1766eac42ea034df92955c95e947ad718624c",
         "dest-filename": "c7d78ed48bb3864e38371db7567b96ab9d94126dfb91cddafd11ced3422e48ed1fa2af446573d188bc3e2fd1766eac42ea034df92955c95e947ad718624c",
@@ -12297,6 +13067,13 @@
         "sha512": "810a674e092e6c2ea142074871175818348373e49aba339dc9eb1940cbfa2657d079effd329d10867cace96c435af4272f9599753ee8d94975f3b692b7446afb",
         "dest-filename": "674e092e6c2ea142074871175818348373e49aba339dc9eb1940cbfa2657d079effd329d10867cace96c435af4272f9599753ee8d94975f3b692b7446afb",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/81/0a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+        "sha512": "da16a6f173d64ce35a8ce474a2138a3875e49b7fa0681986baddd246ebbbe712ddfd145a63abea821f0d058624efe456deee40b733d0646f05d742c7925d2501",
+        "dest-filename": "a6f173d64ce35a8ce474a2138a3875e49b7fa0681986baddd246ebbbe712ddfd145a63abea821f0d058624efe456deee40b733d0646f05d742c7925d2501",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/16"
     },
     {
         "type": "file",
@@ -12405,6 +13182,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+        "sha512": "7ef3b813158c16cab2846dc088f00e6ccb98d65c5aaa061cc5b738f4235d5830c408e24d810cafb0e595c1b65cfaa7f7af346dc688c12be08c12fd0b779098a7",
+        "dest-filename": "b813158c16cab2846dc088f00e6ccb98d65c5aaa061cc5b738f4235d5830c408e24d810cafb0e595c1b65cfaa7f7af346dc688c12be08c12fd0b779098a7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7e/f3"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
         "sha512": "1f125d616ab53132106c9de7c3472ab2c1e84cd536ebb2a5ac3b866755989710d2b54b4a52139a266875d76fd36661f1c547ee26a3d748e9bbb43c9ab3439221",
         "dest-filename": "5d616ab53132106c9de7c3472ab2c1e84cd536ebb2a5ac3b866755989710d2b54b4a52139a266875d76fd36661f1c547ee26a3d748e9bbb43c9ab3439221",
@@ -12503,6 +13287,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+        "sha512": "fb43539d6efb7c537f0e3422ea4fd2abf62f9384a06a3c3bbab5bc57e6ac8d79d1803b3d8321a475bec4ce07e10388285ec44864a136f1fcc85c11c4ce1ba25b",
+        "dest-filename": "539d6efb7c537f0e3422ea4fd2abf62f9384a06a3c3bbab5bc57e6ac8d79d1803b3d8321a475bec4ce07e10388285ec44864a136f1fcc85c11c4ce1ba25b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/43"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
         "sha512": "87715b8ac6b69ca18fc42a66f3d1e4df79412ec9da181bdcb50a2968148e5bfb88b3a1537b5013c809ca149af356cf6fa4676c4deef7585dd5e2522c93819a73",
         "dest-filename": "5b8ac6b69ca18fc42a66f3d1e4df79412ec9da181bdcb50a2968148e5bfb88b3a1537b5013c809ca149af356cf6fa4676c4deef7585dd5e2522c93819a73",
@@ -12549,6 +13340,13 @@
         "sha512": "c8ca8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12",
         "dest-filename": "8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/ca"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+        "sha512": "148aff0c47a81df8fb7ed7f2967a05b77ac0211a165e9c760280dfad3daa0f6c2da7b0e9f8239a8efb3f21c6fbb87a915bd9bad1fe625d9c1db0924ede4bdbef",
+        "dest-filename": "ff0c47a81df8fb7ed7f2967a05b77ac0211a165e9c760280dfad3daa0f6c2da7b0e9f8239a8efb3f21c6fbb87a915bd9bad1fe625d9c1db0924ede4bdbef",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/8a"
     },
     {
         "type": "file",
@@ -12776,6 +13574,18 @@
     },
     {
         "type": "inline",
+        "contents": "0184baa12de89c3fa89277123298ef65b7860e2b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz\", \"integrity\": \"sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==\", \"time\": 0, \"size\": 2273, \"metadata\": {\"url\": \"https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6e7afa40874e544335907e039b7c7b15ba5034389c4849def33f3d9b2f76",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/40"
+    },
+    {
+        "type": "inline",
+        "contents": "018f5097923476b71893c2dd432e2514c8b51c5d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz\", \"integrity\": \"sha512-ghn3muhdn1ailCQqqceNxRgkOeZSVfSE13RQWEg6njB+itsFzGVSJv+O//2hvNXZuxVIRyNzrgsZ37SPDdGJJw==\", \"time\": 0, \"size\": 2978, \"metadata\": {\"url\": \"https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6b99dbd98ba44958e503b9122a047f929092f36b08c040ebfe3f2f25b057",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/46"
+    },
+    {
+        "type": "inline",
         "contents": "01a1f68282b125951c494f3b9e1ca838436fabc1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz\", \"integrity\": \"sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==\", \"time\": 0, \"size\": 5245, \"metadata\": {\"url\": \"https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0c7fe8d180f9f5a5b08c30f8b4fbb4e93b4abaefca6700ee8f0f7ef46a55",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/53"
@@ -12785,6 +13595,12 @@
         "contents": "01c00565b799b2a2ad8d1d419358e4ef36d8c3fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-9.5.0.tgz\", \"integrity\": \"sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==\", \"time\": 0, \"size\": 44526, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-9.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ba2e0f724389afe9916b645aa486202f4dd28493d3be6ed3399afa0fcaea",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/2a"
+    },
+    {
+        "type": "inline",
+        "contents": "01c55395ee039f55b52a6e6c8892ffd8dab4db92\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz\", \"integrity\": \"sha512-qKSGARvao+JQlFiA+sjJZhJ/61gmW/3aNLblB2rsgIxDlDxsJPHo8a1seXj12oKtuHVgJSJJ7QEGBUYQN741lQ==\", \"time\": 0, \"size\": 6084, \"metadata\": {\"url\": \"https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f150329f1494df9cd5e6a9c6995eee7fd2bf17285f993a22b2eefd441495",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/83"
     },
     {
         "type": "inline",
@@ -12842,6 +13658,12 @@
     },
     {
         "type": "inline",
+        "contents": "03338782531576f8c87715e52416877d8e5e88af\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz\", \"integrity\": \"sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==\", \"time\": 0, \"size\": 28026, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dd5e6f02ebea3574006624e5dd81e72b124d66a1bd1598ab078fda7118f7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/cb"
+    },
+    {
+        "type": "inline",
         "contents": "036febb9a6fdac1c5a2d9c05f98deeb2d1ee3dff\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz\", \"integrity\": \"sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==\", \"time\": 0, \"size\": 215688, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "51dfbed131ec9eaaf20db623896c5b5ef754e80f30a74393dbd60d79ed72",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/1e"
@@ -12893,6 +13715,12 @@
         "contents": "04fb850a132630703d4eb79ccc84c87a28ae2b0e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz\", \"integrity\": \"sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==\", \"time\": 0, \"size\": 957027, \"metadata\": {\"url\": \"https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "171e72e0e668639055266d26c4e3fdd786baff13b2dfb5a9bb1e0987fe16",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/55/c1"
+    },
+    {
+        "type": "inline",
+        "contents": "05324d1c87b4cc897f5bb3dccc403b92df5c02fb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz\", \"integrity\": \"sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==\", \"time\": 0, \"size\": 7360, \"metadata\": {\"url\": \"https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "42b7ca0991314841be90b1c10bb54c8508b6234ffabd309de6142e2634e5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/1f"
     },
     {
         "type": "inline",
@@ -13058,6 +13886,12 @@
     },
     {
         "type": "inline",
+        "contents": "090fdaabd3dfad27d65689cd8e4f08b64e1c9017\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz\", \"integrity\": \"sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==\", \"time\": 0, \"size\": 9982, \"metadata\": {\"url\": \"https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6ae2213fa11958a4a3e4ab581d3385ba73ea107e9428cd0687eb11bbb86c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/12"
+    },
+    {
+        "type": "inline",
         "contents": "0934c8aaf82d0a2a702196d9d07f68658f8a1f97\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz\", \"integrity\": \"sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==\", \"time\": 0, \"size\": 415834, \"metadata\": {\"url\": \"https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "364e538e2c7c898ceaf402efbacb5c3ecae4e6e592c22b0c8aadab5f5f2c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/ad"
@@ -13091,6 +13925,12 @@
         "contents": "09f392be16a1aefbc3a4f5b9c5834eff01938bcb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz\", \"integrity\": \"sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==\", \"time\": 0, \"size\": 2014, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ce5dfc760402413c6fce98c74cb96b242ffb0c6d92a26c4dd8ee3af2012d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/6f"
+    },
+    {
+        "type": "inline",
+        "contents": "09f4ba7c71dc02fbcdd7250a7afcae7c26e45676\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.24.0.tgz\", \"integrity\": \"sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==\", \"time\": 0, \"size\": 109438, \"metadata\": {\"url\": \"https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.24.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c0f9b5a23fbf07849406253711c0bfd136b2c068b7b9405b76f177cfc9d0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/49"
     },
     {
         "type": "inline",
@@ -13211,6 +14051,12 @@
         "contents": "0dec3616eeac86e8a6882f4ae35d655ee8e2c902\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz\", \"integrity\": \"sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==\", \"time\": 0, \"size\": 1680, \"metadata\": {\"url\": \"https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "98d70e9e25b9a23c255f11b8acd5d9ebed836d0004871577846f3bc3f03f",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/0c"
+    },
+    {
+        "type": "inline",
+        "contents": "0e0644c6ee30d63e048f03f902a90903bc863f8b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz\", \"integrity\": \"sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==\", \"time\": 0, \"size\": 4501, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8c9adf6a64af9ea0d80a6b4174e0b34efd0696c7400d00836d58c6fd6ae6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/fb"
     },
     {
         "type": "inline",
@@ -13340,6 +14186,12 @@
     },
     {
         "type": "inline",
+        "contents": "106b87fbe6f7b3f1becf42283443d299eec5c38e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz\", \"integrity\": \"sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==\", \"time\": 0, \"size\": 4569, \"metadata\": {\"url\": \"https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4ae74e8552ab1cbf23dc51265cdfcdddab23122ecbc84b56972896897985",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/ef"
+    },
+    {
+        "type": "inline",
         "contents": "1073dab22cf4365ad0991db4fabd71b8ab68805f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz\", \"integrity\": \"sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==\", \"time\": 0, \"size\": 4229, \"metadata\": {\"url\": \"https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0989b8fc498227980548d88ec9e6c0fb7f75d15bade3bad855e90dc540ce",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/fc"
@@ -13436,6 +14288,12 @@
     },
     {
         "type": "inline",
+        "contents": "12fe35503457eb2088bf11b89df8bb8e27ba1ae6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz\", \"integrity\": \"sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==\", \"time\": 0, \"size\": 5784, \"metadata\": {\"url\": \"https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "64c58ca19aebcb3222fb9f0b41d663b061a14435ed65fff8842ae64f0983",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5b/3f"
+    },
+    {
+        "type": "inline",
         "contents": "1321fe01fd1bd8087dd022a8dbeab8c93a8fe65a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz\", \"integrity\": \"sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==\", \"time\": 0, \"size\": 1943, \"metadata\": {\"url\": \"https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5b7b95cdee86846e4fbe92c9e16e0e7f337c77d2c12de9778522b15bed2e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/9e"
@@ -13523,6 +14381,12 @@
         "contents": "1563277afc01408a10777b3770999946fb712467\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz\", \"integrity\": \"sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==\", \"time\": 0, \"size\": 841416, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8820e65946201435762e9be8e347fea9e6e14a8b933fda704b1bd16943ae",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/50"
+    },
+    {
+        "type": "inline",
+        "contents": "15965ebaea603167424ce32676aebffc923226ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz\", \"integrity\": \"sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==\", \"time\": 0, \"size\": 4274, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4f379a74ee63879cb6708274bcb83edcbd3ddea9110e140958e34569510f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/3d"
     },
     {
         "type": "inline",
@@ -13940,6 +14804,12 @@
     },
     {
         "type": "inline",
+        "contents": "1f4695fe9f1a0bd533d6983f319231b3cf81a5c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz\", \"integrity\": \"sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==\", \"time\": 0, \"size\": 17139, \"metadata\": {\"url\": \"https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7319fb6061cb3892bbb090db4fa2758811bb78100120f1cd91f023eec344",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/60"
+    },
+    {
+        "type": "inline",
         "contents": "1f519c9d0c466a7b9d953022e9f022c978d81da5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.1.tgz\", \"integrity\": \"sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==\", \"time\": 0, \"size\": 68082, \"metadata\": {\"url\": \"https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "03baff40942cb146964348571dfa4cd0c80782ff2396ce33a5d8f468b234",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/23"
@@ -14210,6 +15080,12 @@
     },
     {
         "type": "inline",
+        "contents": "252fcae03e77c01520234bd6a24ef25a653c5be3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz\", \"integrity\": \"sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==\", \"time\": 0, \"size\": 5280, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "58c14b3461e0a75ddd4a0be80707cae7f82bf1ef1ae03a0dfc8054aa2570",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/3b"
+    },
+    {
+        "type": "inline",
         "contents": "2554011ad9626671c20d9372ec3867baa7bc9051\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.16.7.tgz\", \"integrity\": \"sha512-BH8sicYOqZ1iBMwCVEGIz6uTTfylosjc49FoMmCYIzKOiYdiVehsfoYBwyfxwWIiya1VMhm1gv0cgOP8fxHpDw==\", \"time\": 0, \"size\": 54206, \"metadata\": {\"url\": \"https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.16.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "fb6eb6f3d4a65d9dee21ffb9ea92db5c40e1b53d3e79eef443786a77448b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/99"
@@ -14225,6 +15101,12 @@
         "contents": "258a9d7dda2b000ca764a5d38903c6a6e3ac5db7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz\", \"integrity\": \"sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==\", \"time\": 0, \"size\": 21147, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8e0a5dd37937f6fc99476efd5a49fbec7b78fbbad5a33614195d972a33b1",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/8b"
+    },
+    {
+        "type": "inline",
+        "contents": "25e63d334802e6e457401ebed8c7af14026cdc96\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz\", \"integrity\": \"sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==\", \"time\": 0, \"size\": 2610, \"metadata\": {\"url\": \"https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "405f7aad425be1ddb0d492bf00b3487c25353b7e8fd64e8fd84147a58a40",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/6d"
     },
     {
         "type": "inline",
@@ -14306,6 +15188,12 @@
     },
     {
         "type": "inline",
+        "contents": "27997f2284e8bfdc4c10c430a3266ac6fa42534d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react/-/react-19.2.7.tgz\", \"integrity\": \"sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==\", \"time\": 0, \"size\": 24805, \"metadata\": {\"url\": \"https://registry.npmjs.org/react/-/react-19.2.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "397e0658002aa87dc4d88eabedb495640f8cff0ed2579127fc01957ac357",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/2d"
+    },
+    {
+        "type": "inline",
         "contents": "27aafd597164c478d57e2dec3aa2898755c63356\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz\", \"integrity\": \"sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==\", \"time\": 0, \"size\": 29348, \"metadata\": {\"url\": \"https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f060e36740da477c0a62451fe262e2e01df7a5c5c69b1a6230aa13930f9c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/a8"
@@ -14354,6 +15242,12 @@
     },
     {
         "type": "inline",
+        "contents": "284fdf45ccad288296cefa343ff325be1ece7554\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz\", \"integrity\": \"sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==\", \"time\": 0, \"size\": 15062, \"metadata\": {\"url\": \"https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "53f2c91b42805b157c8a22ed765861bf9a4c2b0c3e7e4be5108f6caeaad7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/fa"
+    },
+    {
+        "type": "inline",
         "contents": "28512f2f3de55bd2dcfee4dc8b2152990fc59e19\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz\", \"integrity\": \"sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==\", \"time\": 0, \"size\": 5179, \"metadata\": {\"url\": \"https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6799e52a12dedc4a8cca2afd9ff0a0f444219aece66ac340a7aaf4c02923",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/6f"
@@ -14363,6 +15257,12 @@
         "contents": "286e788925f4162d212f44cb0401e6cc70098e50\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz\", \"integrity\": \"sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==\", \"time\": 0, \"size\": 2886, \"metadata\": {\"url\": \"https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c542915e5eae0c169241ac70dc471be3f9781350cd8c79684d430eb63338",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/5b"
+    },
+    {
+        "type": "inline",
+        "contents": "2894b7f169c7d520dfa5e535c48be78478690108\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz\", \"integrity\": \"sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==\", \"time\": 0, \"size\": 21478, \"metadata\": {\"url\": \"https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "07ebf25fea1c20b52db9e54c6d6da248519ed6fded68d96e8e3623f56d0f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/ea"
     },
     {
         "type": "inline",
@@ -14393,6 +15293,12 @@
         "contents": "2930579f0e6922aebc13b34561db457fbe31a85e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz\", \"integrity\": \"sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==\", \"time\": 0, \"size\": 50253, \"metadata\": {\"url\": \"https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d68969bc13e00be23565448f892a66e4e8c4ae9a434939ae8e5758f73332",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "298c1197917465a6c3f55f043e4387d2d8563dbc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz\", \"integrity\": \"sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==\", \"time\": 0, \"size\": 13729, \"metadata\": {\"url\": \"https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "255987692ed4b32b3993ff6ef663e6bd09a1a03610cb48772db1744998b8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fe/66"
     },
     {
         "type": "inline",
@@ -14498,6 +15404,12 @@
     },
     {
         "type": "inline",
+        "contents": "2cc85aa6595a18f0907d6c7628c2f33a896fa5ff\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz\", \"integrity\": \"sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==\", \"time\": 0, \"size\": 10016, \"metadata\": {\"url\": \"https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "86e90e6ce56553b2b3325172b0bf0208e2311f42864c3134e953f237c338",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/71"
+    },
+    {
+        "type": "inline",
         "contents": "2ce5b33d53451a37fda1baf341258ba40b624f94\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.11.2.tgz\", \"integrity\": \"sha512-FWnOm2MORX/nt8psnEtID3Vnt8Blby1NkzjU3KjXBPF9kave71C3lI8KbBbCeKKyTQ/S00i2FiglKdRWQ1WNTw==\", \"time\": 0, \"size\": 5409, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9a282b86a5e87dc220397c9117032e8fb95f0f284311f44c436716bb362a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/ec"
@@ -14510,9 +15422,21 @@
     },
     {
         "type": "inline",
+        "contents": "2d15d0e15179feddcb29eaf328abe02219dc6d83\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz\", \"integrity\": \"sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==\", \"time\": 0, \"size\": 55571, \"metadata\": {\"url\": \"https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "837415657bb0d1ef414a0d478edfcdb71b06b60db3067da2a057aa58de66",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/e0"
+    },
+    {
+        "type": "inline",
         "contents": "2d656f4a4ba9d0302a365f8255219f5edc7fbd10\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz\", \"integrity\": \"sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==\", \"time\": 0, \"size\": 11398, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e236d9a349e738c8841f9d14a32f0d4d269da22830565d660e941dc2ff4e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/45"
+    },
+    {
+        "type": "inline",
+        "contents": "2d6ab2e7cb501c736a98544263b63904506513b8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz\", \"integrity\": \"sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==\", \"time\": 0, \"size\": 173034, \"metadata\": {\"url\": \"https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "24a5977420471d8bf54333d2c9356dd18376e0d123b7f3acaa7371e8a021",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/0b"
     },
     {
         "type": "inline",
@@ -14642,6 +15566,12 @@
     },
     {
         "type": "inline",
+        "contents": "311590c5f5fff488a62c956d36a4bfa405779127\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz\", \"integrity\": \"sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==\", \"time\": 0, \"size\": 180002, \"metadata\": {\"url\": \"https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "32c48c847df485cd23d95d2e9bef120c31052b0452925cc069e73fac64e0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/fc"
+    },
+    {
+        "type": "inline",
         "contents": "31508559ebcac34d89c702e570a8c7257ed7606b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz\", \"integrity\": \"sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==\", \"time\": 0, \"size\": 28311, \"metadata\": {\"url\": \"https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f31162d986f3ebd62c15c67dbf1944038a0720b074c31384310e37df038c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/6a"
@@ -14663,6 +15593,12 @@
         "contents": "31b431627f9addc0ad94591ed03580b06e7a63ff\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz\", \"integrity\": \"sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==\", \"time\": 0, \"size\": 1961, \"metadata\": {\"url\": \"https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "49afeccff92e878481e549c9076c272e9a0cb462d11fcd4b6c3fed1954a8",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/fc"
+    },
+    {
+        "type": "inline",
+        "contents": "31c1f7e86a39ae1fac2e25156ae2e5da8c878664\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz\", \"integrity\": \"sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==\", \"time\": 0, \"size\": 7794, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cb7ad32d08bee1179164ddb9b9a0006ebe38e5e2d97e445bff9dabbb9fed",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/26"
     },
     {
         "type": "inline",
@@ -14846,6 +15782,12 @@
     },
     {
         "type": "inline",
+        "contents": "3628146f9f7c66c0ddcae371037197775614d6eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz\", \"integrity\": \"sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==\", \"time\": 0, \"size\": 9493, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f9625f6a113591d788f295d9cd8a7293e96b712c63a7b2727e744df79ab1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/68/0e"
+    },
+    {
+        "type": "inline",
         "contents": "362c57e3d1c70e4b77021667947d9ddb57a4baba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-2.0.1.tgz\", \"integrity\": \"sha512-SVqEcMZBsZF9mA78rjzCrYrUs37LMJk3ShZ851ygZYW1cMeIjs9mL57KO6Iv5mmjSQnOe/29/VAfGXo+oRCiVw==\", \"time\": 0, \"size\": 2751, \"metadata\": {\"url\": \"https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ac8574c5ea51b64eda90bdd58e79043e126cc4915f87881c4e3d45aefec7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/0f"
@@ -14861,6 +15803,12 @@
         "contents": "3651bdb93acafd4e171ccb4a97614b50f865217a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/recast/-/recast-0.23.11.tgz\", \"integrity\": \"sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==\", \"time\": 0, \"size\": 53707, \"metadata\": {\"url\": \"https://registry.npmjs.org/recast/-/recast-0.23.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9a2e6acc034e826a5a046a7267afb48f77c673b755469593fb80cbbbcd55",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "366bc2737307d5962d5bd164504f09c7a259b03f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz\", \"integrity\": \"sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==\", \"time\": 0, \"size\": 4146, \"metadata\": {\"url\": \"https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c9a02e9328cfbec3920d7c8cc7fb10bd4818b3ee2734e44cb288a1fa38a8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/74"
     },
     {
         "type": "inline",
@@ -15068,6 +16016,12 @@
     },
     {
         "type": "inline",
+        "contents": "3ab0e62fe465d709629e89e90e30730792f12e13\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz\", \"integrity\": \"sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==\", \"time\": 0, \"size\": 8083, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e72117e4892594ad942e805985edef3ca75efd1730b0ff9041f2af01d165",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/68"
+    },
+    {
+        "type": "inline",
         "contents": "3ae349c081d103357d8912b6a54a399180748476\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz\", \"integrity\": \"sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==\", \"time\": 0, \"size\": 3652, \"metadata\": {\"url\": \"https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f74042740cf491b55667cf1a269361282f02fa1c0ae653bffc8ea4b9e242",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/a5"
@@ -15122,6 +16076,12 @@
     },
     {
         "type": "inline",
+        "contents": "3bd642c86d0099076204548449418cbeb8ec0403\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz\", \"integrity\": \"sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==\", \"time\": 0, \"size\": 5064, \"metadata\": {\"url\": \"https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5f426285c7d8a666694a7f987731760c151e85591b72fb047e2171695abf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/90"
+    },
+    {
+        "type": "inline",
         "contents": "3bf888d0f85fddceff67193efa4e7ff3ed70989a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz\", \"integrity\": \"sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==\", \"time\": 0, \"size\": 4658, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6a5b57ca4d63f37ccae38ea6b710ed659eeb763c63181c02e9470f8b29b9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/e3"
@@ -15137,6 +16097,18 @@
         "contents": "3c48c36dec0f617e777ffaccee953bbc79fa6aec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.2.tgz\", \"integrity\": \"sha512-5kwCfWml7+b2NO7KrLMhYihjRx0teKkd3yGp1Xk5Vaf2JGdSh+rgVhEALAD9c/59dP+YwJHXoEO7e8QPy7gOkw==\", \"time\": 0, \"size\": 4870, \"metadata\": {\"url\": \"https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "faca3db17a975333be0253e1e78fa90987a5bf0370e32f291ad1f72c1445",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/47"
+    },
+    {
+        "type": "inline",
+        "contents": "3c4beb574c19b30e3a828ac5d563a99846f54cff\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/process/-/process-0.11.10.tgz\", \"integrity\": \"sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==\", \"time\": 0, \"size\": 4669, \"metadata\": {\"url\": \"https://registry.npmjs.org/process/-/process-0.11.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "92f118c0a24e357ec8a38491a4d9817ff3ea5911377130948c4e480c7f23",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/fb"
+    },
+    {
+        "type": "inline",
+        "contents": "3c6094c5a0993a19388394e9b70ea878c61972b3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz\", \"integrity\": \"sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==\", \"time\": 0, \"size\": 12477, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "49eeedc3ad4bf696cd66aeadfa4a0e789efc8ecd2c293b28bd25da9d5006",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/95"
     },
     {
         "type": "inline",
@@ -15281,6 +16253,18 @@
         "contents": "3e4930055828420c8d9aa5e4003fd9c615a013e8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz\", \"integrity\": \"sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==\", \"time\": 0, \"size\": 10600, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "528c5445a438483b66270e6a4dddfa6e9bdcceb2b998cb6f7580d23ceb1b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/60"
+    },
+    {
+        "type": "inline",
+        "contents": "3e6792f444739a4bf2b6f2397747b3a94b9df08f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/util/-/util-0.12.5.tgz\", \"integrity\": \"sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==\", \"time\": 0, \"size\": 9981, \"metadata\": {\"url\": \"https://registry.npmjs.org/util/-/util-0.12.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8af230a0228226da5c90f31c3828d41c59a278902e70e410c872a84a3fa6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/22"
+    },
+    {
+        "type": "inline",
+        "contents": "3e71f8ad373eeaf33308face826abaffb009e52f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz\", \"integrity\": \"sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==\", \"time\": 0, \"size\": 5621, \"metadata\": {\"url\": \"https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d1ecc7c21317b4624adc7b61b6e4b2aa384a4cd0fd7b7b6c5f3c76be8889",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9c/ce"
     },
     {
         "type": "inline",
@@ -15590,6 +16574,18 @@
     },
     {
         "type": "inline",
+        "contents": "4646b75b8bc72479b0ffe8fc3318bbf255928002\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.1.tgz\", \"integrity\": \"sha512-sNp13PrxYLaUFHTGoDKkSDFvoEu51bfzE12RwGlqU1fcrkpAOK0NvizaJzOWV0Omtk9me2+Pnbjcf/l0efxuGQ==\", \"time\": 0, \"size\": 7397, \"metadata\": {\"url\": \"https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "21d5eb38d6d477d273b6a32b56452350b3b8493f5fa77ea611df63468efb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/74"
+    },
+    {
+        "type": "inline",
+        "contents": "4649b5787464ffb6b9b953595cebf9d8b000eaec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz\", \"integrity\": \"sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==\", \"time\": 0, \"size\": 2710, \"metadata\": {\"url\": \"https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4511be3eecea50ee9cadc09a612f9be8598d7b29d5c8b1253c75fa283cc5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/ac"
+    },
+    {
+        "type": "inline",
         "contents": "4652be2559307226f28e173972e602022155833f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.4.1.tgz\", \"integrity\": \"sha512-IWg2FeB9OzxDky3q885MqepN2QEujyGdbcCB0VbHB3zRpT2D2fbk87FIy64JGoZkPVmoI4d7Mbxa+XKFS4jlrw==\", \"time\": 0, \"size\": 5529696, \"metadata\": {\"url\": \"https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "01509e2dd6b4aaaa302105e38b04eb743aa048601c9f1dee375fed4b5473",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/d2"
@@ -15617,6 +16613,12 @@
         "contents": "4706471689377c69e5a5aa66bec39998d1ac1014\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/expo-glass-effect/-/expo-glass-effect-55.0.11.tgz\", \"integrity\": \"sha512-wqq7GUOqSkfoFJzreZvBG0jzjsq5c582m3glhWSjcmIuByxXXWp6j6GY6hyFuYKzpOXhbuvusVxGCQi0yWnp3g==\", \"time\": 0, \"size\": 12272, \"metadata\": {\"url\": \"https://registry.npmjs.org/expo-glass-effect/-/expo-glass-effect-55.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "bfd577cbdd5fdd999d9bdf64458975b20cac6cf7c8273ccf8753ac8074be",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/d0"
+    },
+    {
+        "type": "inline",
+        "contents": "470accc58f25b7dddb5414a44c6cda0fe27f35ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz\", \"integrity\": \"sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==\", \"time\": 0, \"size\": 4227, \"metadata\": {\"url\": \"https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5caaabc9fe3ab8889fcf19048b9dbfd439646935cdca76172a6e0ced554a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/28"
     },
     {
         "type": "inline",
@@ -15665,6 +16667,12 @@
         "contents": "47ef9be3458655fc5321e7280bac7a9a3e428bc2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz\", \"integrity\": \"sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==\", \"time\": 0, \"size\": 21819, \"metadata\": {\"url\": \"https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d310a29f72bfe4cc1b2f0565f3e434a9eaa7a4d13ee4c41afbbf3132d7f8",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/e2"
+    },
+    {
+        "type": "inline",
+        "contents": "483f9a6909d0fc3e0879d561b45c95c433d4bea6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz\", \"integrity\": \"sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==\", \"time\": 0, \"size\": 12196, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3138ee53103ab2efce8bd66b74135b337b6169f3e08b3f48ec9551a510ba",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5f/54"
     },
     {
         "type": "inline",
@@ -15968,6 +16976,12 @@
     },
     {
         "type": "inline",
+        "contents": "4f19519e87f9d02da1cb7a55c57176ef164b384e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz\", \"integrity\": \"sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==\", \"time\": 0, \"size\": 5694, \"metadata\": {\"url\": \"https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ae69ff41985ebecd1d09ef7bfad34847ed912256590de61502b9351161c4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/38"
+    },
+    {
+        "type": "inline",
         "contents": "4f29c2de7854a29c04ef945d82419c720951eeb8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sax/-/sax-1.6.0.tgz\", \"integrity\": \"sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==\", \"time\": 0, \"size\": 16571, \"metadata\": {\"url\": \"https://registry.npmjs.org/sax/-/sax-1.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "4f0500aa0af94771e3aeb0a7db7153faf4f245521a4095d765a465f508ce",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/26"
@@ -16160,6 +17174,12 @@
     },
     {
         "type": "inline",
+        "contents": "52f358b2bd9e98c15e361a92736e49c7cbcaeb4c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz\", \"integrity\": \"sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==\", \"time\": 0, \"size\": 3270, \"metadata\": {\"url\": \"https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d09e5ae5db81e465a4f1df36682b6848d7d258ff3d137f8682c06ff6ab6a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/fb"
+    },
+    {
+        "type": "inline",
         "contents": "5303ecac9edf87ecd037aa1147b80f0de4f36f08\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.11.2.tgz\", \"integrity\": \"sha512-4CILo57ZDEQH1mJxjhYCSXuv+WaU7oPq67KqiTLEUOEzmiPg9u9/z7FXE34H/Tn5aKWN3dy+ngAETzv6iERCGg==\", \"time\": 0, \"size\": 4741, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ee7abad716fa1b57e2a1dce4e8940779db8572e602c13adb1ac67dfe0120",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/c5"
@@ -16196,9 +17216,21 @@
     },
     {
         "type": "inline",
+        "contents": "5372573824686da544391d8ebc5ec04e743ce6f7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz\", \"integrity\": \"sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==\", \"time\": 0, \"size\": 4178, \"metadata\": {\"url\": \"https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7ddb4c1006d61ed231108052ffe4f8fb3ee024ada57c80b415f27b2c77c0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/a9"
+    },
+    {
+        "type": "inline",
         "contents": "5386eae7cb2a805a93c3b4069fb5e9c9b107f376\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz\", \"integrity\": \"sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==\", \"time\": 0, \"size\": 4633345, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "dd8d47e4b369381eaf15fddaec4de0ba403256fd68866c4ee25514e686df",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/6b"
+    },
+    {
+        "type": "inline",
+        "contents": "539da075c54510a38cf5c6c9056868b3b5724cdb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz\", \"integrity\": \"sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==\", \"time\": 0, \"size\": 82956, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c7ac3bc940509322dbcad243f1c1d89c776734cf5ae960cddc1fae49e691",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/18"
     },
     {
         "type": "inline",
@@ -16448,6 +17480,12 @@
     },
     {
         "type": "inline",
+        "contents": "597ab2ddd83adbc6fd0366a3d42f0633d11249bd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz\", \"integrity\": \"sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==\", \"time\": 0, \"size\": 8058, \"metadata\": {\"url\": \"https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a2298c2f64b56df1319cf932ed1a97353fe7308186742be561467bddc7e5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/82"
+    },
+    {
+        "type": "inline",
         "contents": "59c6e999a405a1bc28d5ea2c4846a9a450fee56d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz\", \"integrity\": \"sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==\", \"time\": 0, \"size\": 3060, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8cbab322150a907404391ad4927a8ed9a63841592a7782ee11c42d795426",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/eb"
@@ -16616,9 +17654,21 @@
     },
     {
         "type": "inline",
+        "contents": "5cd4989fa7357d2a48fe5cbe83d9e057c281d558\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz\", \"integrity\": \"sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==\", \"time\": 0, \"size\": 2294, \"metadata\": {\"url\": \"https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8a8862f9abef39caaef5c9976900aa158f2576c051f8ec17747b9ce86ab8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/cb"
+    },
+    {
+        "type": "inline",
         "contents": "5ce27e275304acda7f3387d8fe9303cf1afd37e4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz\", \"integrity\": \"sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==\", \"time\": 0, \"size\": 18451, \"metadata\": {\"url\": \"https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5df1ff8d784183182074e18d903143fd52dfeb2142f08cebbafa8469667e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/ff"
+    },
+    {
+        "type": "inline",
+        "contents": "5cf824b097841dac666604cfe1c004f790e1be8c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@hyperswarm/dht-relay/-/dht-relay-0.4.3.tgz\", \"integrity\": \"sha512-bjiBnVOtm/vXF7RO6CGK6fQOMmhb4LMmgOlbPrNrEvf2CWzAfam6klXQ4DgKb1GY86KGiNCnSoB6TimNgaobbg==\", \"time\": 0, \"size\": 14976, \"metadata\": {\"url\": \"https://registry.npmjs.org/@hyperswarm/dht-relay/-/dht-relay-0.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3b446d327647c4dc5e9b4e7c86a53de048a8c5f4f81d6699e2062754530d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/f2"
     },
     {
         "type": "inline",
@@ -16730,6 +17780,12 @@
     },
     {
         "type": "inline",
+        "contents": "5f52ee7238f6b5be921e38d44de1c5f9fadaa876\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz\", \"integrity\": \"sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==\", \"time\": 0, \"size\": 8050, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c1045e828e8bd90f1df1526b6f6421dd096f8bd29809058a7a4a3dad4900",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/58"
+    },
+    {
+        "type": "inline",
         "contents": "5f6031c3f83027eb857ef842527a0e60925e35dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz\", \"integrity\": \"sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==\", \"time\": 0, \"size\": 6852, \"metadata\": {\"url\": \"https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "367c7e18003b796b193cac7de1a85e450474986c6f4dd6a79dfd6dae02c4",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/a2"
@@ -16739,6 +17795,12 @@
         "contents": "5f8120abd516a06436803aa0768139a346a864cd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz\", \"integrity\": \"sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==\", \"time\": 0, \"size\": 4521, \"metadata\": {\"url\": \"https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5f01dce87163b20c9c209fd3a3a1c9bf6c3f7de4a63436be40e76d952ebf",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/58"
+    },
+    {
+        "type": "inline",
+        "contents": "5f9871680f16a59d717a0562961bb17ccfd2c723\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/qs/-/qs-6.15.3.tgz\", \"integrity\": \"sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==\", \"time\": 0, \"size\": 71213, \"metadata\": {\"url\": \"https://registry.npmjs.org/qs/-/qs-6.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "15d330c83f0ad89709e8c9c754fba025217cc79553febce637a1da18b058",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/c5"
     },
     {
         "type": "inline",
@@ -16802,6 +17864,12 @@
     },
     {
         "type": "inline",
+        "contents": "60eb892aef0e2409465ab2d454b1798fe61c5fcc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz\", \"integrity\": \"sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==\", \"time\": 0, \"size\": 6202, \"metadata\": {\"url\": \"https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a978c26265eae7fc2b6e9e249c6fd9f6dc2eb1aa76a85f00b5436a1def98",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/cb"
+    },
+    {
+        "type": "inline",
         "contents": "60f2c290aaf3901355649af90f5de790ef958072\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz\", \"integrity\": \"sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==\", \"time\": 0, \"size\": 816234, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "454a23fb492945b4b14134ab7e3d288f5af33913a49337bd7b5f6d40834b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/c5"
@@ -16817,6 +17885,12 @@
         "contents": "610bd84f2a3ebe4fdd45c48de4f9c57af36ca3c8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz\", \"integrity\": \"sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==\", \"time\": 0, \"size\": 1679, \"metadata\": {\"url\": \"https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "35ebdea6cf3cf61c1c81d8bc8ff75f7dd29c9d56870dc839c952fbad1c79",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/9a"
+    },
+    {
+        "type": "inline",
+        "contents": "611dbc40a1d36270d88554b8142b3ab8b184596f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz\", \"integrity\": \"sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==\", \"time\": 0, \"size\": 21900, \"metadata\": {\"url\": \"https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "db7e0cf242b9125e503c9606a9ccac1cf46bd51142b8c2e8343c47b553ad",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/d6"
     },
     {
         "type": "inline",
@@ -16847,6 +17921,12 @@
         "contents": "61b44b257048d421c5d3308e7af5f869a2c16c8a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz\", \"integrity\": \"sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==\", \"time\": 0, \"size\": 3446, \"metadata\": {\"url\": \"https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "4e020eef80700cb3f93d867eba934f2b586e90d19ab0707fd54abc8ff7e9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/3a"
+    },
+    {
+        "type": "inline",
+        "contents": "620e9f1a88ec378103557d6cc5869b9bb6e10681\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz\", \"integrity\": \"sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==\", \"time\": 0, \"size\": 2667, \"metadata\": {\"url\": \"https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "882487cf503a0f7c92cb27da2cf620c653623431e854df597e0a88107975",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/a1"
     },
     {
         "type": "inline",
@@ -16922,6 +18002,12 @@
     },
     {
         "type": "inline",
+        "contents": "64c7a3a0f94b9bddc92702fa72506dfaf25a7cc3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz\", \"integrity\": \"sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==\", \"time\": 0, \"size\": 1654, \"metadata\": {\"url\": \"https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2407adde9d05bdd552950df201bc4af8db37f56e8a766823f9a3893a2107",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/fb"
+    },
+    {
+        "type": "inline",
         "contents": "64caccc6ee1de554107e8a3e4aa3f91bdd0adbee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pear-aliases/-/pear-aliases-1.0.7.tgz\", \"integrity\": \"sha512-Z85C0naSKh3XMBKm1P1L2kYbIGE+Ph0HRSjTaQz5O99JvQq/wHylu9M2df1Ysfx7LG3UJrCCwZenrud18bZytw==\", \"time\": 0, \"size\": 5018, \"metadata\": {\"url\": \"https://registry.npmjs.org/pear-aliases/-/pear-aliases-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ff8a61de5c29a0c953ab49b46547714284347458fdf430d1ce57deae69e7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/d7"
@@ -16985,6 +18071,12 @@
         "contents": "65a79e38d915d1f3474a4bd949710b731a95cf44\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz\", \"integrity\": \"sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==\", \"time\": 0, \"size\": 1788163, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2d45efa8e75b0fdc05fd3dd05dca5aeea4c11cdc5470ed5df3a6b24ca95a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "66301fe5916e47fef23f150f97b4d91ea4e55965\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz\", \"integrity\": \"sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==\", \"time\": 0, \"size\": 5442, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f306f68eac58ac50c3a0a0453cb8f29d78b9505c01947c965b4768a4e60d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/98"
     },
     {
         "type": "inline",
@@ -17120,6 +18212,18 @@
     },
     {
         "type": "inline",
+        "contents": "6873535f9dc5e674c8d6cd9a5452090529af3728\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz\", \"integrity\": \"sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==\", \"time\": 0, \"size\": 2814, \"metadata\": {\"url\": \"https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dc057644e678600be87a0a5f5e89ed29b1f5e887fc5ac7b78abdebf775c2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/b1"
+    },
+    {
+        "type": "inline",
+        "contents": "689802e69302b051579b52a6bfdd3760c007afa9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz\", \"integrity\": \"sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==\", \"time\": 0, \"size\": 4059, \"metadata\": {\"url\": \"https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e46885db4f12f39bbe35e54f17d925a8d51166869ad8be3dec1593facc6f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/25"
+    },
+    {
+        "type": "inline",
         "contents": "68f564140c592c4f1e64586672d73993310c8c32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz\", \"integrity\": \"sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==\", \"time\": 0, \"size\": 1894, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "393eb6f1cdd50a93cb92ed56af16a93821a9263f732f369d831c48199a58",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/c1"
@@ -17162,6 +18266,12 @@
     },
     {
         "type": "inline",
+        "contents": "6a3c12851504064213758404cd30a65e6dd1c42d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz\", \"integrity\": \"sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==\", \"time\": 0, \"size\": 1586, \"metadata\": {\"url\": \"https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2f4488cef82b4ddf93f8c79be73dd728aec42a6e57f023f2acc73392e809",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/69"
+    },
+    {
+        "type": "inline",
         "contents": "6a65c2af2bfb4d4278d2685226c409cb2be34c4b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz\", \"integrity\": \"sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==\", \"time\": 0, \"size\": 495135, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "a474ad84e4264a9c37041a3fae746bbf2fb591271f815b4cb92c0e290be2",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/5f"
@@ -17177,6 +18287,12 @@
         "contents": "6aa949a931d90c5f5ec20dfef5e044c474b36bc5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz\", \"integrity\": \"sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==\", \"time\": 0, \"size\": 1667, \"metadata\": {\"url\": \"https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c09ade35321bb5a7e4a11198039528e1fa0e99be86176d281064a8b71732",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/20"
+    },
+    {
+        "type": "inline",
+        "contents": "6abf27966bb44d6d1950d1be66e90cdd9ca953e6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz\", \"integrity\": \"sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==\", \"time\": 0, \"size\": 2363, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "110d233146554ee89a7fa12e7d5ae1b6d85ce1ae82a859a6b8516925a64d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/80"
     },
     {
         "type": "inline",
@@ -17339,6 +18455,12 @@
         "contents": "6e790956da3032f8ddd5ccd137f9f94438256f65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz\", \"integrity\": \"sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==\", \"time\": 0, \"size\": 619500, \"metadata\": {\"url\": \"https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c034daad693e314d201e09b45deb813228729c8a3e017cd31b49656d37e6",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "6eb8747fbc15656f7d36beb343c9674d7c43256a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz\", \"integrity\": \"sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==\", \"time\": 0, \"size\": 11594, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "015cf75b124419cc457a4d4cf6b3b1829afa11bfd7ffaec669b295ccc4da",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/5a"
     },
     {
         "type": "inline",
@@ -17588,6 +18710,12 @@
     },
     {
         "type": "inline",
+        "contents": "75010ed233b95650187b294f4022954473e1f571\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz\", \"integrity\": \"sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==\", \"time\": 0, \"size\": 12480, \"metadata\": {\"url\": \"https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "72f4169859bdab637b3a8327c44310f1b5bb53b10d6f7651be2bdc75ab37",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/dc"
+    },
+    {
+        "type": "inline",
         "contents": "75015aab7c236920622d44e5b6bc7c652d3b7b26\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shuffled-priority-queue/-/shuffled-priority-queue-2.1.0.tgz\", \"integrity\": \"sha512-xhdh7fHyMsr0m/w2kDfRJuBFRS96b9l8ZPNWGaQ+PMvnUnZ/Eh+gJJ9NsHBd7P9k0399WYlCLzsy18EaMfyadA==\", \"time\": 0, \"size\": 3197, \"metadata\": {\"url\": \"https://registry.npmjs.org/shuffled-priority-queue/-/shuffled-priority-queue-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "4a9b63daaf7008c0c482682f9389be3bcbea9369117908ae70aaac97458c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a6/2f"
@@ -17714,6 +18842,12 @@
     },
     {
         "type": "inline",
+        "contents": "770aac848d8f25f885665670d379591baeec3094\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz\", \"integrity\": \"sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==\", \"time\": 0, \"size\": 4441, \"metadata\": {\"url\": \"https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9929becbd070991a0b1e204d86bcd47f937337869b6a9fc383e0ac50c8bc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/9a"
+    },
+    {
+        "type": "inline",
         "contents": "77649f7eb01cf6d3816ed1fefb9a139c1acf4ac3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz\", \"integrity\": \"sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==\", \"time\": 0, \"size\": 6215, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "aa2963609015952b7265560957bf41da4bd96554abcdba7d3c9a9acce9fe",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/a7"
@@ -17768,9 +18902,21 @@
     },
     {
         "type": "inline",
+        "contents": "7887bf5d6463b7f8ad4b1daca3599bfd2dbdb717\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.4.tgz\", \"integrity\": \"sha512-akWoxJPGCB3aZCrZ+fm6VIFhJ/p8idBv7AWGFng/CZIrQo51oQNsvDbTSRXWAzIiZJvpy16oIDiCCPqTe21sKg==\", \"time\": 0, \"size\": 6795, \"metadata\": {\"url\": \"https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "04bc9a13b3b75bfb5885a8a2692a0725d63b3cfe8ab6606103b6a2540025",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/04/f5"
+    },
+    {
+        "type": "inline",
         "contents": "788dde1a1bccf85bd1e8ec4e441c806507e926c9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz\", \"integrity\": \"sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==\", \"time\": 0, \"size\": 4662, \"metadata\": {\"url\": \"https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7c199fba9261b92a884e4e207b05388761c224a6f43097aeca01664cd8a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/73"
+    },
+    {
+        "type": "inline",
+        "contents": "788fdd1149297cd2ce853b3b8c4532a33734f7b1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz\", \"integrity\": \"sha512-kehYuigMoRkIngCv7rhgruLJNNHDnitGTBdkcYbCbooL8Cidj/bS78MDxByIjcc69M915WxcQTgZetZ1JbeQTQ==\", \"time\": 0, \"size\": 4265, \"metadata\": {\"url\": \"https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c5bfc5b610c7439a6f3e5a6682e6f7a001a32d64762752279e362613b015",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/07/ce"
     },
     {
         "type": "inline",
@@ -17825,6 +18971,12 @@
         "contents": "797f9e97f477534c05ddf2e2cda81adb2939a5f9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.4.tgz\", \"integrity\": \"sha512-8os0weQEnjUhWy7Db881+JKRwNHVGM40VtTRvltAyA/YYkrGg4kPCqiTybMxQDEcF3rnviuxHyI+ITiglfmgmQ==\", \"time\": 0, \"size\": 17573, \"metadata\": {\"url\": \"https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "bfdccb96afcbe3431c6935406fb60568559c32316226b621f36875c522e5",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/4b"
+    },
+    {
+        "type": "inline",
+        "contents": "79a0adfd78390caa60cab0884f72e7d35909496a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz\", \"integrity\": \"sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==\", \"time\": 0, \"size\": 6135, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c34658b94967a2498f75a66b8ff6c87e60d36be229f7c9912de8f9a258b5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/f6"
     },
     {
         "type": "inline",
@@ -17966,9 +19118,21 @@
     },
     {
         "type": "inline",
+        "contents": "7c7bf910670d7e76632a774043385057beb2d5b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz\", \"integrity\": \"sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==\", \"time\": 0, \"size\": 2486, \"metadata\": {\"url\": \"https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f61ca387a7ed9b00827926afce0942c99f654891beddade885c6262969fd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/c0"
+    },
+    {
+        "type": "inline",
         "contents": "7ca1aaff10735a730d04e84a69646d25e5c28145\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"integrity\": \"sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==\", \"time\": 0, \"size\": 26992, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "53e431efe5d40277f768cec075f9e7f618f2296715654a7b953121078b1e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/14"
+    },
+    {
+        "type": "inline",
+        "contents": "7d049084a358b6c5f5b29c3e9f3f67b7191ce191\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz\", \"integrity\": \"sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==\", \"time\": 0, \"size\": 22034, \"metadata\": {\"url\": \"https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "df1ebf79e0cf234c6f99d2da69ffa1d3a2ea16ff67987a91adac0fb3e910",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/61/ac"
     },
     {
         "type": "inline",
@@ -18026,6 +19190,12 @@
     },
     {
         "type": "inline",
+        "contents": "7e96c3ef651c4b58e4ce01df61dea4a9e0436db1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz\", \"integrity\": \"sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==\", \"time\": 0, \"size\": 8133, \"metadata\": {\"url\": \"https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0c9c490aadb716682d8b29edd42f1a4f7b84c17046376df2ab1209f7025a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/d5"
+    },
+    {
+        "type": "inline",
         "contents": "7e9ac69f05a892391a7941064e950d8e90aad070\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz\", \"integrity\": \"sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==\", \"time\": 0, \"size\": 8211583, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "fbe77be0433a1efe78543c93fe7554c4b69186ce9a347ef4be9f5626fabe",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/a0"
@@ -18053,6 +19223,12 @@
         "contents": "7edebfcea27419818fcecc98233551e2bf37b07f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz\", \"integrity\": \"sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==\", \"time\": 0, \"size\": 3860279, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7769abd49ef04e280175cba38fc1b174e6031761cfc8178127bcc4e3aab",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "7ef031f89113cf4ea904d7a491452e0bf81b792f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz\", \"integrity\": \"sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==\", \"time\": 0, \"size\": 13647, \"metadata\": {\"url\": \"https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cee4c32210d789769c97530c96caabd3828b11226013bf6845653919124b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/95"
     },
     {
         "type": "inline",
@@ -18119,6 +19295,12 @@
         "contents": "808365d5b6377e5042b3cae0ad7b68c52be5cdc1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz\", \"integrity\": \"sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==\", \"time\": 0, \"size\": 33668, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "25bb9615aa16691191832dc6466eb46a9cc028781c1801cc71d928fb4d4a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/45"
+    },
+    {
+        "type": "inline",
+        "contents": "8106616008c24c7300e8dd09ba1d3866f1070616\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz\", \"integrity\": \"sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==\", \"time\": 0, \"size\": 5356, \"metadata\": {\"url\": \"https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "eb69c661e6c4241c35beb04ee530ae4a056953c159f685e2627ae83b6714",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/90"
     },
     {
         "type": "inline",
@@ -18245,6 +19427,12 @@
         "contents": "83b607531c9403f236eef341bd7d67c846f3b123\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz\", \"integrity\": \"sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==\", \"time\": 0, \"size\": 7148, \"metadata\": {\"url\": \"https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "568978145b27751823960effe6f29407039d51cf02f412396a1be7bf460e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/50"
+    },
+    {
+        "type": "inline",
+        "contents": "83ba264d18672afecdec6e71a9890e9bb0e989f9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz\", \"integrity\": \"sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==\", \"time\": 0, \"size\": 48061, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2a1ccea34577e53ed2e858b7a1f0330c712ddd08e730932ed7af3c27ef22",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/1e"
     },
     {
         "type": "inline",
@@ -18389,6 +19577,12 @@
         "contents": "874a9b5e899290ea79c643a3ef26c9e1ccbc68a3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz\", \"integrity\": \"sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==\", \"time\": 0, \"size\": 3810, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "40122c5cee651bb244e17448855ba7beb1ffc43ef9d58d74671626ebedb0",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/e0"
+    },
+    {
+        "type": "inline",
+        "contents": "87a4a7985d99182254f2259d6de8bebbcf0d6847\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz\", \"integrity\": \"sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==\", \"time\": 0, \"size\": 2021, \"metadata\": {\"url\": \"https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "43bc4bbdabf8ae0454ee7075000f4ba27acf124106cdb71a445723bbc8c9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/5c"
     },
     {
         "type": "inline",
@@ -18590,6 +19784,12 @@
     },
     {
         "type": "inline",
+        "contents": "8c19f21e1d3222180aed1126e1b908b5b11dbf7f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz\", \"integrity\": \"sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==\", \"time\": 0, \"size\": 2509, \"metadata\": {\"url\": \"https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a015c93ed9c5bc9054519fa8ac0d39d7e1e7ddf207201205859d6995a920",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/15"
+    },
+    {
+        "type": "inline",
         "contents": "8c33e8124bc919be3adaf5d581eab20229739178\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/msix-manager/-/msix-manager-0.2.5.tgz\", \"integrity\": \"sha512-bfAqCBIIoxCsBCuDCr9wCfucmL0fy8jE4GBf9Yx24ZXDxQe4L7r/CJcNcGQxWx9RdHGCqCuNKrrNLfTYOue3fw==\", \"time\": 0, \"size\": 285431, \"metadata\": {\"url\": \"https://registry.npmjs.org/msix-manager/-/msix-manager-0.2.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "58c24558406ed3b7bedbbe4e9713cd318d50319e3b855c4546518b919a63",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/b9"
@@ -18611,6 +19811,12 @@
         "contents": "8c9b477af0084b3e4b0fdce366762ed11ab0e69e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz\", \"integrity\": \"sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==\", \"time\": 0, \"size\": 13369, \"metadata\": {\"url\": \"https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0380559f2aa3f48d6733aadf8843d8e3d9f1b92eaaa125de918fc91bbe9b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/e2"
+    },
+    {
+        "type": "inline",
+        "contents": "8d127c7f6038e76b2f6cb2d1f34cbac59fe49191\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz\", \"integrity\": \"sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==\", \"time\": 0, \"size\": 4831, \"metadata\": {\"url\": \"https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "469da539f6f336e366cb9edec72814077ffd341100a28dfb8cca1408d9af",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/73"
     },
     {
         "type": "inline",
@@ -18791,6 +19997,12 @@
         "contents": "90b59f72872ec57664c7acf74d94f7b89b6c524e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz\", \"integrity\": \"sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==\", \"time\": 0, \"size\": 8607, \"metadata\": {\"url\": \"https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "282935d7dd7863ac8f4d1af401a3c32aa261ddfd2e8495f831be94a8796a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/92"
+    },
+    {
+        "type": "inline",
+        "contents": "90bb9afa1bee5f0a296bd36ddad899d1f9d8b574\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz\", \"integrity\": \"sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==\", \"time\": 0, \"size\": 3383, \"metadata\": {\"url\": \"https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fcb527174dbcf271a081540ef048d7de5b5156834c375bed22f892fee38e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/1d"
     },
     {
         "type": "inline",
@@ -18998,6 +20210,12 @@
     },
     {
         "type": "inline",
+        "contents": "9421208d932a67688fe8e9c2a0029734efdb1b47\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz\", \"integrity\": \"sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==\", \"time\": 0, \"size\": 4906, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "71a26cd31577ac61ca7eb7b618a481a2f072505d3ff1025bbebd74f77b47",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f6/6e"
+    },
+    {
+        "type": "inline",
         "contents": "94ab05a57a80abe3da014e8fa0d0ea2221032751\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz\", \"integrity\": \"sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==\", \"time\": 0, \"size\": 17544, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "cbe69fec139759199ea70f787a7ac72777aef164153140226f7608da029c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/0f"
@@ -19025,6 +20243,12 @@
         "contents": "950089bd577fbd02c30c1680124320e0d5b3a3b0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz\", \"integrity\": \"sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==\", \"time\": 0, \"size\": 5209, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3b5dd0653ba0f115da876ae43657bf7453b4aa462b850f2d45dc68945790",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/52"
+    },
+    {
+        "type": "inline",
+        "contents": "950fa5de245114a31496d23fb49f94e9c22373e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz\", \"integrity\": \"sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==\", \"time\": 0, \"size\": 3147, \"metadata\": {\"url\": \"https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d8278926ef08a6a3dac798b135f5282536c82d8a02f7d240733720bd4dab",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/cd"
     },
     {
         "type": "inline",
@@ -19172,6 +20396,18 @@
     },
     {
         "type": "inline",
+        "contents": "99c999e3051a839359c22ad7122c2218fb8fb8ce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz\", \"integrity\": \"sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==\", \"time\": 0, \"size\": 2429, \"metadata\": {\"url\": \"https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d5f460d73029905b34f612862dc69172122c0b20103b254400cbf5bddb77",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dc/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "99e21a341130d12cfcb627956ecb982490e0631e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz\", \"integrity\": \"sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==\", \"time\": 0, \"size\": 5762581, \"metadata\": {\"url\": \"https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c78df5f99416a44a4e0eafc6c796d5077a27eb60e0c143b8e08865ec0bb9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/aa"
+    },
+    {
+        "type": "inline",
         "contents": "99ec2f33f3c6530b04200f479bb0a7f2e3191f1a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz\", \"integrity\": \"sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==\", \"time\": 0, \"size\": 32679, \"metadata\": {\"url\": \"https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "119f67269d825f31edcc5339b2bbd15e984164719e3ea04a21bda619f3cd",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/51"
@@ -19205,6 +20441,12 @@
         "contents": "9ac64a980e2a0ca49985b6c7e8dcc5e7f94c6a69\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz\", \"integrity\": \"sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==\", \"time\": 0, \"size\": 4111, \"metadata\": {\"url\": \"https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "4313d559739f2998050c4b1bcfc5ffa04c9bcef5bf4c0b25e564c7a33601",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/07"
+    },
+    {
+        "type": "inline",
+        "contents": "9ac798a3407319bd6185c94ad93e3f6221e18ee6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz\", \"integrity\": \"sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==\", \"time\": 0, \"size\": 12589, \"metadata\": {\"url\": \"https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0956fe9a3ebca9157a53a1d74d5a5ae809b066ed213de4c1a1c8df6b1140",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5f/e5"
     },
     {
         "type": "inline",
@@ -19271,6 +20513,12 @@
         "contents": "9c9ef10d5008111bc72ab2ca6189ae4309596f6e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz\", \"integrity\": \"sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==\", \"time\": 0, \"size\": 2000, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "88a96d346e7eb30dfd96e7819f96aff750aaec1cfee7503c5bf030563a38",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/9a"
+    },
+    {
+        "type": "inline",
+        "contents": "9cc532e37af48823ba2b683a95a38e523f6bfe0f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz\", \"integrity\": \"sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==\", \"time\": 0, \"size\": 5334, \"metadata\": {\"url\": \"https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4f031ed2694bbb8ee7acb4dc08c27773cb1cd48a2c1178934e95ec630ed3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/26"
     },
     {
         "type": "inline",
@@ -19526,6 +20774,12 @@
     },
     {
         "type": "inline",
+        "contents": "a2c6b13ca421d20668e3669d1845b0d1d92f12d6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz\", \"integrity\": \"sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==\", \"time\": 0, \"size\": 25747, \"metadata\": {\"url\": \"https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5cb3f47ba8a17b62a575c388705c516448f9426b5f1e0bbbbe6f21f223d8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/3f"
+    },
+    {
+        "type": "inline",
         "contents": "a2ca864cfaea25699df81e129095316ae07f8956\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz\", \"integrity\": \"sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==\", \"time\": 0, \"size\": 11377, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "211d19f87bd3d47c875f803133fab6d0d895cb6f8284f41b2b3fee63f93d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/ec"
@@ -19682,6 +20936,12 @@
     },
     {
         "type": "inline",
+        "contents": "a4ee88f0d35669a5fbc15bc2d7c9227675212da1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz\", \"integrity\": \"sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==\", \"time\": 0, \"size\": 9822, \"metadata\": {\"url\": \"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4c69aba00431d506e9b53306eba6929ed6581502d7e8c77cb340635745a1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1d/66"
+    },
+    {
+        "type": "inline",
         "contents": "a4fa4bd17c4f4cf372f04fa2c118efcb8749c2a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz\", \"integrity\": \"sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==\", \"time\": 0, \"size\": 3965, \"metadata\": {\"url\": \"https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5f0f5600d4f6c8cd5287991a72adc9ee514c0139a77a26e8dd6e3ef107fe",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/83"
@@ -19691,6 +20951,12 @@
         "contents": "a4fb3f13d4cbe146489e69542e7dbe62ce3c7001\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz\", \"integrity\": \"sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==\", \"time\": 0, \"size\": 796050, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9d0f9d1d99b48c5c139061a43774b52735084ded4c5079ea95849dd50d96",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "a53a79a2a8d82f018472787139b5fc37765716eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz\", \"integrity\": \"sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==\", \"time\": 0, \"size\": 5368, \"metadata\": {\"url\": \"https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4870679e4f723cb7b67e4c547864bb0b190579c16845ec9ac08e4703afc5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/39"
     },
     {
         "type": "inline",
@@ -19715,6 +20981,12 @@
         "contents": "a59554e49c4973b60638d98b6c501320307cfcb5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz\", \"integrity\": \"sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==\", \"time\": 0, \"size\": 3623980, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "fe34e86449b27a938bd4a20bff5470f22e6d63f9809807f7539b7b84a7d2",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/43"
+    },
+    {
+        "type": "inline",
+        "contents": "a599a9aa6bf5e12c78d6f2a7abcdcd7a29fbd3fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz\", \"integrity\": \"sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==\", \"time\": 0, \"size\": 2310, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "26e1eefb7973416048973248a0ff777c191a856b99d3a53be82c4092d938",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/e8"
     },
     {
         "type": "inline",
@@ -19760,6 +21032,12 @@
     },
     {
         "type": "inline",
+        "contents": "a6bf570f7dc2f1c495e80ee2775816e90d680985\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz\", \"integrity\": \"sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==\", \"time\": 0, \"size\": 6596, \"metadata\": {\"url\": \"https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0e48024b7059aa315de3e9aa176c1418ddcdedbecdbe6b18425e8e86d692",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/4b"
+    },
+    {
+        "type": "inline",
         "contents": "a6c7de3d560e1ef780d175f4652724f681eadfa2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.9.1.tgz\", \"integrity\": \"sha512-xb0S5y3YJwBakD77JOGBHlBxdp63mHClZoXBYoLv+9wH8e054ESKlmQptWqjJK5dv5VMUIVYOJB4MaOpB0JdGw==\", \"time\": 0, \"size\": 10903, \"metadata\": {\"url\": \"https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e54c42d1f3b5540065ad9d61b0f46421c25b08f23ee4360ca82291c3b5f5",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/bc"
@@ -19787,6 +21065,12 @@
         "contents": "a6e42048ba1f2ef5b0f329f62d185e9b5b05fe24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz\", \"integrity\": \"sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==\", \"time\": 0, \"size\": 3411, \"metadata\": {\"url\": \"https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6d7bae213a75c7ad8674ad544ee18279d95ed5fc0503dc5b8c88f2b36662",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/4c"
+    },
+    {
+        "type": "inline",
+        "contents": "a6eeb0243f9e864b8e7daadd480a7f79b29ffd40\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ws/-/ws-8.21.1.tgz\", \"integrity\": \"sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==\", \"time\": 0, \"size\": 34995, \"metadata\": {\"url\": \"https://registry.npmjs.org/ws/-/ws-8.21.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8cd926c8b23f9c7316228d4e82e9b56df3ea7b4c50cf699697c7104070f1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/b5"
     },
     {
         "type": "inline",
@@ -19943,6 +21227,12 @@
         "contents": "aa37106e8199c76c53e8936b814e6b15f3e1081b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz\", \"integrity\": \"sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==\", \"time\": 0, \"size\": 74047, \"metadata\": {\"url\": \"https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "687d06c73f9846fec2b7b4285793aba81f89708f82db640dc47cc6dc0d10",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/88/70"
+    },
+    {
+        "type": "inline",
+        "contents": "aa69947b05d4ec29d2f95df05c29b34d5601b51b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz\", \"integrity\": \"sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==\", \"time\": 0, \"size\": 41251, \"metadata\": {\"url\": \"https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e25ac7cbb3996a24199fffedd22e77e37e5ef20846f6c29a0d1988ef4712",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/67"
     },
     {
         "type": "inline",
@@ -20132,6 +21422,12 @@
     },
     {
         "type": "inline",
+        "contents": "aea6cfabbe9eb457386bca1d151c6245de221de7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz\", \"integrity\": \"sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==\", \"time\": 0, \"size\": 5135, \"metadata\": {\"url\": \"https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d557ee53742d7836d061d38e61750f64e4c1b9402a28d79bf62875241fd3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/39"
+    },
+    {
+        "type": "inline",
         "contents": "aed264ff456d1434b6d03d6c6bd9c5f785e9acd4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz\", \"integrity\": \"sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==\", \"time\": 0, \"size\": 1621, \"metadata\": {\"url\": \"https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "fc46f5c221a0049b2c5ce36c0d6d7514868921f50b2b985f87959a60a217",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/08"
@@ -20306,6 +21602,12 @@
     },
     {
         "type": "inline",
+        "contents": "b37f5983eeb7c7e69cb47060a6040822ddd45849\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz\", \"integrity\": \"sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==\", \"time\": 0, \"size\": 1020, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b59670335a0aa4dfeedc38d3dc68f775e4a8fda0311b471b4a28b308bfb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/1b"
+    },
+    {
+        "type": "inline",
         "contents": "b3802fca04fbbb80bee337c97e6c3bd39afb00fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz\", \"integrity\": \"sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==\", \"time\": 0, \"size\": 4929, \"metadata\": {\"url\": \"https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "008c383bee6a68a34abbc038e22309e6cd58db2aed4d4cddcf661ec2ef3a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/01"
@@ -20345,6 +21647,12 @@
         "contents": "b4823fdaf6f04833adfbf77e0eddbd663a1d87c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz\", \"integrity\": \"sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==\", \"time\": 0, \"size\": 3700, \"metadata\": {\"url\": \"https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3da612d5ae7122a8de3b302e48ca71841aa3111ecf11fa25919816c6a25e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/41"
+    },
+    {
+        "type": "inline",
+        "contents": "b48cb70e92453edfddefc79bfddb82015c98e362\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz\", \"integrity\": \"sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w==\", \"time\": 0, \"size\": 9775, \"metadata\": {\"url\": \"https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1a8c7129cc990c1848542d237645858d580b3c6bdea3ad2e4114b17ef177",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/bb"
     },
     {
         "type": "inline",
@@ -20450,6 +21758,12 @@
     },
     {
         "type": "inline",
+        "contents": "b6e509eb1f90af9266ebee3f4eab78745056f986\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz\", \"integrity\": \"sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==\", \"time\": 0, \"size\": 12509, \"metadata\": {\"url\": \"https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "682afe35c301b1c41e787ca2df86854e300c4867ec8205581b10f715cba3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/b7"
+    },
+    {
+        "type": "inline",
         "contents": "b730bc681cfb5a4867f3791f096f59e3edcecb33\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz\", \"integrity\": \"sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==\", \"time\": 0, \"size\": 17548, \"metadata\": {\"url\": \"https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2572e4f6479b462303996e05223b531b7f58c8edfbab4c0654964109ab80",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/e0"
@@ -20465,6 +21779,12 @@
         "contents": "b745685fcb5e6aad5c2aaa5cad6a53843ee6c022\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz\", \"integrity\": \"sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==\", \"time\": 0, \"size\": 68950, \"metadata\": {\"url\": \"https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9d455fd6a3fa92a55f971fe809bf7c1df88def0cbad6b942d11b7d013d22",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/60"
+    },
+    {
+        "type": "inline",
+        "contents": "b77937f636bbdfa644c6f17ba6cea7ac22a557cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.3.tgz\", \"integrity\": \"sha512-ABj07mmHrK3FC8fJ3PP5QCrbA31zkB4Qg34NFmYgwJnBxzfbRmtMzOg54PL55OG5sFjvmBzD0q85JAtRlA3dSA==\", \"time\": 0, \"size\": 2718, \"metadata\": {\"url\": \"https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dffc83f62bf3bbab142aefb0d49aa3d0b546944332c256edabe12a14dd4d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/f0"
     },
     {
         "type": "inline",
@@ -20552,6 +21872,12 @@
     },
     {
         "type": "inline",
+        "contents": "b8d28279dcdf644149b276be87b2f2e05afa419a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz\", \"integrity\": \"sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==\", \"time\": 0, \"size\": 1253, \"metadata\": {\"url\": \"https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "62d9c3d8456991585320af22caaa0f06ce697630ddc75e7019e74cf42d8e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/de"
+    },
+    {
+        "type": "inline",
         "contents": "b8f19237f3bffe58d06f3d094368d3ded9e52e09\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz\", \"integrity\": \"sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==\", \"time\": 0, \"size\": 1704, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "dd5667485e64fd49c7ecc3baed7e67eed4659ceb2331b4fc282ff0f771f4",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/c7"
@@ -20573,6 +21899,12 @@
         "contents": "b9778af040b396a62db19ee990290fe5d7456982\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.4.5.tgz\", \"integrity\": \"sha512-2q5+VxlRiyJ2T/kniAv+oI760ZL8veyrqr9N6Dn0M9iif+Zz6DAUpoVzHyid+hI7NO6Bqb73u30QUvdTUGjBEA==\", \"time\": 0, \"size\": 112081508, \"metadata\": {\"url\": \"https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.4.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f1a4111488ad0feea6cd804277f349a3de8836e45b9d61905298570a1e76",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/2b/32"
+    },
+    {
+        "type": "inline",
+        "contents": "b9a250c68eb4f0fde8990d843d764166b4c696a6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz\", \"integrity\": \"sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==\", \"time\": 0, \"size\": 2444, \"metadata\": {\"url\": \"https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bd70187805a5320bcd35861fc40c30e7c032b45d360206c2a88f8e7cc983",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d8/ce"
     },
     {
         "type": "inline",
@@ -20633,6 +21965,12 @@
         "contents": "bc071c15d122e841b8ec82fc0e4fb1a870881ff8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"integrity\": \"sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==\", \"time\": 0, \"size\": 6318, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "216edd7104928342f4e596f226b589b3733c83a5c056ece5738890de4460",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/20"
+    },
+    {
+        "type": "inline",
+        "contents": "bc2a51b59fa8210b8fa3b758b683bb37315b6a84\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz\", \"integrity\": \"sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==\", \"time\": 0, \"size\": 12166, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "39f6d7930cf40aebc27bee418d0ec4dbdd4c0065941db5b2e957b5c8185e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/65"
     },
     {
         "type": "inline",
@@ -20771,6 +22109,12 @@
         "contents": "beb3581a096857eef74eaedeca49d285be4518ea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz\", \"integrity\": \"sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==\", \"time\": 0, \"size\": 135815, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c28913cbc3407b3ee6a1dd1f8b3e6a714f62604f554104e211c8c6a58574",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "bef3e96b06d374d81926621e7a9460cc7ea4c36d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz\", \"integrity\": \"sha512-rEBzR5mPxPES+UjyMDvKPIXy9ImF17KOJ32nJNi9uIquWpS/nfj+h6m05J5yLJaGXjgM72LmQoUbWZVxh/rmGg==\", \"time\": 0, \"size\": 18785, \"metadata\": {\"url\": \"https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1dd4758137921bc7d4c630ac861fc75d008f8b6433374d71ac36bc6fd17b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/78"
     },
     {
         "type": "inline",
@@ -21014,6 +22358,12 @@
     },
     {
         "type": "inline",
+        "contents": "c3e143f1f9ba17b4738200e1245ae1a338d73739\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz\", \"integrity\": \"sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==\", \"time\": 0, \"size\": 5117, \"metadata\": {\"url\": \"https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a7ba36353295a9ccb5b95fedd6bffc965c659ef90156665af1c0e73f9fbd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/0c"
+    },
+    {
+        "type": "inline",
         "contents": "c3e73a4fdf826a443b77f7b98d35e619047c0b04\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz\", \"integrity\": \"sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==\", \"time\": 0, \"size\": 12734, \"metadata\": {\"url\": \"https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d5debeb17bb28081cc5cba9a982b26f3aa9fb5c41f851662f8b3536b2379",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/88"
@@ -21029,6 +22379,12 @@
         "contents": "c41c0429c3b566154ad7d71291cb2dccfaaefcd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz\", \"integrity\": \"sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==\", \"time\": 0, \"size\": 2989, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e8166faad33ceb76841ce09c5e5e619d46225021c61320e9f0882993d698",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/0b"
+    },
+    {
+        "type": "inline",
+        "contents": "c4a2c19f05442c9cc154f5890207bdaa5100b742\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz\", \"integrity\": \"sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==\", \"time\": 0, \"size\": 1276388, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "22347d1721246f752485786de37a4d95a795f3ac9aa9209db61bf3527f1a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/07/d4"
     },
     {
         "type": "inline",
@@ -21134,6 +22490,12 @@
     },
     {
         "type": "inline",
+        "contents": "c7439ae2196800ad203ecbf1f39fb3387512751a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz\", \"integrity\": \"sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==\", \"time\": 0, \"size\": 20235, \"metadata\": {\"url\": \"https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b5ea342b3713a4c921a4d28afdbde5ec3f9c42ae5e4995d5a63bb20735e0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/22"
+    },
+    {
+        "type": "inline",
         "contents": "c74c5920851820af877e33d81cbd8828971b97a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz\", \"integrity\": \"sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==\", \"time\": 0, \"size\": 4488997, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "b6e21a0c8528f88427789410162ac063243dc43a10fbfb1a6ec58b4937a8",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/1f"
@@ -21218,6 +22580,12 @@
     },
     {
         "type": "inline",
+        "contents": "c960fa8cbcfd7ec2d71426e7780e2cb0cc1b2a13\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz\", \"integrity\": \"sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==\", \"time\": 0, \"size\": 1859, \"metadata\": {\"url\": \"https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b1ca3753d1cd1c428b248d18f3e58c4e5d1e143498967a41b9106116bd57",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/b8"
+    },
+    {
+        "type": "inline",
         "contents": "c96901391f9c2cf93f0e3cbb9366ee594210e048\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz\", \"integrity\": \"sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==\", \"time\": 0, \"size\": 6480, \"metadata\": {\"url\": \"https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8b648af4e005ff65e7bdfec5e6cf341cf58d9efbf55d2d80a7f74d48720a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/32"
@@ -21227,6 +22595,12 @@
         "contents": "c977e92ef87f84645b5b8994b2a625329e57884f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz\", \"integrity\": \"sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==\", \"time\": 0, \"size\": 2355, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "73b35a8f4302e381cef7266dbeb6cb1428cb5a313ea163a3a3145e1fc642",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/09"
+    },
+    {
+        "type": "inline",
+        "contents": "c98a4329a107a5646a8e2e34b784dfcf5f813019\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz\", \"integrity\": \"sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==\", \"time\": 0, \"size\": 8508, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fafea17497e34875cdfc85f9ec081bfb0fe97498207476b7cc8721edbaab",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/fa"
     },
     {
         "type": "inline",
@@ -21338,6 +22712,12 @@
     },
     {
         "type": "inline",
+        "contents": "cce11136adc4cf8fed4ac62cb10bfdafa2a31b42\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz\", \"integrity\": \"sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==\", \"time\": 0, \"size\": 9896, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "76df126d9b6d7061bf86eae6b8b042ec84484bd9fa245eea8faef5d2332a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/99"
+    },
+    {
+        "type": "inline",
         "contents": "ccf2abb094c4a3a6e197e833c5721d45d856cbbf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz\", \"integrity\": \"sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==\", \"time\": 0, \"size\": 10978, \"metadata\": {\"url\": \"https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f9db367edb8f679b11df27b48c582195f79a39a7fece0603ce62a83e26a3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/1b"
@@ -21383,6 +22763,12 @@
         "contents": "cdb3fac81504f211269cc6aa7e06edf4265ee2da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.83.4.tgz\", \"integrity\": \"sha512-AhaSWw2k3eMKqZ21IUdM7rpyTYOpAfsBbIIiom1QQii3QccX0uW2AWTcRhfuWRxqr2faGFaOBYedWl2fzp5hgw==\", \"time\": 0, \"size\": 103592, \"metadata\": {\"url\": \"https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.83.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "dce79facae937be0859f60afdfdf472ce8425d5b8fe44df99d1bd675a922",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/7d"
+    },
+    {
+        "type": "inline",
+        "contents": "cdc72c5a06c70d2d150fd7f5f28f4ae2aa3bb3ca\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz\", \"integrity\": \"sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==\", \"time\": 0, \"size\": 3039, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8176fa5373de4e410bb19fd8e3b5349956d544204492dd48cb67e716bdf9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/8d"
     },
     {
         "type": "inline",
@@ -21467,6 +22853,12 @@
         "contents": "cfa95a120e5c3470caefe0d496ee516a71affecb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz\", \"integrity\": \"sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==\", \"time\": 0, \"size\": 14851, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3be998789dcf66f862c15079c4308e6f4c888e42a6e3fe76ce3702925373",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ff/44"
+    },
+    {
+        "type": "inline",
+        "contents": "cfcadacf3a7147608935efbd38f221f90b93624b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz\", \"integrity\": \"sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==\", \"time\": 0, \"size\": 1594, \"metadata\": {\"url\": \"https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9d929673a691ecc22cae436cfdd660dbea30a4adb3a8373f1b82671ca958",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dc/2b"
     },
     {
         "type": "inline",
@@ -21668,6 +23060,12 @@
     },
     {
         "type": "inline",
+        "contents": "d4441c73fbff3efd52ea9ce826ba612a986d198b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz\", \"integrity\": \"sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==\", \"time\": 0, \"size\": 12945, \"metadata\": {\"url\": \"https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b89f15464be45704ea3afcd6f87952a3d2f9c7f383e548406139a161690e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/01"
+    },
+    {
+        "type": "inline",
         "contents": "d450ed14d79b507065508fe87d884a23186112ba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz\", \"integrity\": \"sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==\", \"time\": 0, \"size\": 202724, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "7f5b1c22a459a524f032a961bfc12d557754cbf1670d01de840100035dd3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/05"
@@ -21800,6 +23198,12 @@
     },
     {
         "type": "inline",
+        "contents": "d74e31cc610bdbeb90c7e5a66193e6cc7690ec50\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz\", \"integrity\": \"sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==\", \"time\": 0, \"size\": 3255, \"metadata\": {\"url\": \"https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bd0ca62cf5353023a90b6b037f55945cd0a4130010992e9583f149496354",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/87"
+    },
+    {
+        "type": "inline",
         "contents": "d758da460d2138399b64a431ce2617103506c9a8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz\", \"integrity\": \"sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==\", \"time\": 0, \"size\": 190116, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "282a52d7ff98e5c2b63589e7ac3942da557cb7fbf6b14be414452ca7de4d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/31"
@@ -21827,6 +23231,12 @@
         "contents": "d809000d81bedc02a2981a8abfa2020c52301295\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz\", \"integrity\": \"sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==\", \"time\": 0, \"size\": 24243, \"metadata\": {\"url\": \"https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0b32153730005e22607ffcddad09fc8bf08bcc3ec3ec2d5c20997f8fae07",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/07/18"
+    },
+    {
+        "type": "inline",
+        "contents": "d80ec1825ba681c5361042ea3685084388c7ee6c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz\", \"integrity\": \"sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==\", \"time\": 0, \"size\": 7454, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "67976929ccc2e2a9b563f4bbfd3086265131cb09adf646e6bb43c334cdb1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/cb"
     },
     {
         "type": "inline",
@@ -22013,6 +23423,12 @@
         "contents": "dc6aa41d4bfcddc1b9cdb968ff0bd034f21c6f07\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz\", \"integrity\": \"sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==\", \"time\": 0, \"size\": 2567, \"metadata\": {\"url\": \"https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5c605d6f1ee71d7bf47b826ce0ca46e5e7f0b3d2423313a65f002131616d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/22"
+    },
+    {
+        "type": "inline",
+        "contents": "dc74aca7598abd69d948325edaf144cf3435d3f9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz\", \"integrity\": \"sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==\", \"time\": 0, \"size\": 4931, \"metadata\": {\"url\": \"https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f8a665228ebe3ab7271516fa9b8c8d94b8b7236f540770ff6811a4ffe839",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/9e"
     },
     {
         "type": "inline",
@@ -22454,9 +23870,21 @@
     },
     {
         "type": "inline",
+        "contents": "e5d4abd4bc380e44c7f787c63e6b6def02322b14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chacha20-universal/-/chacha20-universal-1.0.4.tgz\", \"integrity\": \"sha512-/IOxdWWNa7nRabfe7+oF+jVkGjlr2xUL4J8l/OvzZhj+c9RpMqoo3Dq+5nU1j/BflRV4BKnaQ4+4oH1yBpQG1Q==\", \"time\": 0, \"size\": 5357, \"metadata\": {\"url\": \"https://registry.npmjs.org/chacha20-universal/-/chacha20-universal-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a1f7e999c652642ef56ffae5c13d1c526924be3c33600f03c28a36516b2b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/db/38"
+    },
+    {
+        "type": "inline",
         "contents": "e5ee13734d082e76f338e1c7b6037f8b482ac34c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz\", \"integrity\": \"sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==\", \"time\": 0, \"size\": 2822, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "426d9e205dc4ed0aff7c534b89733c3b5d09e37bfcde46b86d3b0e2dab70",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/87"
+    },
+    {
+        "type": "inline",
+        "contents": "e616d92213de1618fb0c357955eb9135f788167e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz\", \"integrity\": \"sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==\", \"time\": 0, \"size\": 6382, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5912d88421e6b76e5e0365ae8015aac3093d6e53b5b60fdfa91116720417",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/e2"
     },
     {
         "type": "inline",
@@ -22592,6 +24020,12 @@
     },
     {
         "type": "inline",
+        "contents": "e8eec5e2cf13c8b448e9dd2ac0e9aa0b6017ddcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pako/-/pako-1.0.11.tgz\", \"integrity\": \"sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==\", \"time\": 0, \"size\": 204482, \"metadata\": {\"url\": \"https://registry.npmjs.org/pako/-/pako-1.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c9acbe48d825a0797e5d17c5ea77170c89cae0b587f9e7c8d8e1840432bf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/b8"
+    },
+    {
+        "type": "inline",
         "contents": "e907c0e842454b436f48aa6285eeb5add8438988\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz\", \"integrity\": \"sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==\", \"time\": 0, \"size\": 1878, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "34b8f549d763f9583ffbafa18d2b62d1ce4c0aa482ae63a65de156b49543",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/df"
@@ -22706,6 +24140,12 @@
     },
     {
         "type": "inline",
+        "contents": "eb5d06dcd9f685bdaed204d1b836e23587523e26\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz\", \"integrity\": \"sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==\", \"time\": 0, \"size\": 11027, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a80a14e820f32fa00164502bd78a26f7b0d2e6e2db3eb40cbc39ac62b5b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/94"
+    },
+    {
+        "type": "inline",
         "contents": "eb5dc2f3c6b23e637ecb2f506865e15e24380d65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz\", \"integrity\": \"sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==\", \"time\": 0, \"size\": 2472, \"metadata\": {\"url\": \"https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2953701ac0c3bbcad9386cb5df0c034fbdfc47242f902c888707f6346f12",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/92"
@@ -22802,6 +24242,12 @@
     },
     {
         "type": "inline",
+        "contents": "edd5fa032078595e8a1712eefb5ec59e2633d31a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz\", \"integrity\": \"sha512-moemC3ZKiTzH29nbFo3Iw8fbemWWod4vNs/WgKbQ54oEs6mE6XVlguxvinYjB+UmaE0PThgyED9fUkWvirT8hA==\", \"time\": 0, \"size\": 5388, \"metadata\": {\"url\": \"https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ce17d146a9c01ce84a6bba0c5ad4b25a3bcf656cd243f10f60e99054e85c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/1e"
+    },
+    {
+        "type": "inline",
         "contents": "ee0c82cca3132124e77ad801fb71d90890ce905e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hypercore/-/hypercore-11.30.1.tgz\", \"integrity\": \"sha512-pu4zcs4DsKZWhRZRXNIC3RW+I8mYOG0VWDEWklVlt+INCpEbJoGwgqQSK8iIq1rAdOuT/omnELQNGnqtNI57OA==\", \"time\": 0, \"size\": 83760, \"metadata\": {\"url\": \"https://registry.npmjs.org/hypercore/-/hypercore-11.30.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "bc9f33a3146b66844d7cdd3b300b8d33f6463c7c7599c3ce19ff8e6660e6",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/d2"
@@ -22865,6 +24311,12 @@
         "contents": "eeaabe6f6b39860b5dbe911d8f17a6f71195fa67\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.3.tgz\", \"integrity\": \"sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA==\", \"time\": 0, \"size\": 665441, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "303ab52042311640eeec7d2acd5c12296eed8d23a1be1d08cc2363e35cc0",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/40"
+    },
+    {
+        "type": "inline",
+        "contents": "eedd55f8d7ac3c33eb58b2b45b7646e753a5feeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz\", \"integrity\": \"sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==\", \"time\": 0, \"size\": 436285, \"metadata\": {\"url\": \"https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b4127e1546d80436c24a48bee5efd56772c82d0ebad30a7df3776c03bde8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/b3"
     },
     {
         "type": "inline",
@@ -23090,6 +24542,12 @@
     },
     {
         "type": "inline",
+        "contents": "f6007b64a183ef420a1fb68114cf9ff5fe000e18\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/url/-/url-0.11.4.tgz\", \"integrity\": \"sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==\", \"time\": 0, \"size\": 18322, \"metadata\": {\"url\": \"https://registry.npmjs.org/url/-/url-0.11.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "22bcd772543a2c7493c659bf2fb409ba6c8758229abafb198084b194147d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/c5"
+    },
+    {
+        "type": "inline",
         "contents": "f602d86c854a1c89c4308bd1b0c49c48c4699bee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz\", \"integrity\": \"sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==\", \"time\": 0, \"size\": 2225, \"metadata\": {\"url\": \"https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9c0a4a732dd35bed214e9a08461ce3f5bf49acbc2ad9e5ce6d8d0e90f7ff",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/3f"
@@ -23138,6 +24596,12 @@
     },
     {
         "type": "inline",
+        "contents": "f702dc41960e270239ca25638a9aee0f10f0c6cd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz\", \"integrity\": \"sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==\", \"time\": 0, \"size\": 2374, \"metadata\": {\"url\": \"https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b6be4f3781d1cb714a2eef1cf1dbb268dc9bcb2b73a90e4b7f32eabf0931",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/a2"
+    },
+    {
+        "type": "inline",
         "contents": "f70d659c393a0b1568d2566939a29a673075308e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz\", \"integrity\": \"sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==\", \"time\": 0, \"size\": 4167, \"metadata\": {\"url\": \"https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "72e4066925771005c149cda2faae3c90d10e0c7de2b4b9585f053d8fa4c9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/a8"
@@ -23159,6 +24623,12 @@
         "contents": "f7d3f7650411766b35b2def93ef5f39cc51e1e33\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz\", \"integrity\": \"sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==\", \"time\": 0, \"size\": 207830, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "31f9aa29658115263d61505a3e09112e36d5129f905de7c0188cf6ebe425",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/2a"
+    },
+    {
+        "type": "inline",
+        "contents": "f7d559b2f6f9c562562f701e6d9ba8a0ef30f4a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/assert/-/assert-2.1.0.tgz\", \"integrity\": \"sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==\", \"time\": 0, \"size\": 21877, \"metadata\": {\"url\": \"https://registry.npmjs.org/assert/-/assert-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "578bd094b517aba95fde5f92f894581fcf2afb8a7dcee0421daf05d1f907",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/fe"
     },
     {
         "type": "inline",
@@ -23372,6 +24842,12 @@
     },
     {
         "type": "inline",
+        "contents": "fc8fd702b1dd29c4a20f422e2f222efb77aec0f8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/noise-handshake/-/noise-handshake-3.1.0.tgz\", \"integrity\": \"sha512-0S1qkUvMbTvZCfgr/vSkVT84YyvI4Q0OLwSc5BFxVmjaePrxAwVeXeJDY3A7N/7+qj95gZ15LaNoP9ZnBXH5Lw==\", \"time\": 0, \"size\": 9322, \"metadata\": {\"url\": \"https://registry.npmjs.org/noise-handshake/-/noise-handshake-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "326d8b73030798a389bfcc496d67fca195bcc0767d0038875d20f1e43b96",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/2a"
+    },
+    {
+        "type": "inline",
         "contents": "fcd35da05f9c87a2f7725b0457d2f4579eec1bf2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz\", \"integrity\": \"sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==\", \"time\": 0, \"size\": 11106, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c8d4583d3ccd74993cd4f903c6c061c4ce30fbfede60b4bb8856e13cfae9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/f8"
@@ -23501,6 +24977,12 @@
         "contents": "ffaa2ca1a6e940ca9a998cabc2422a338e9a1816\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz\", \"integrity\": \"sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==\", \"time\": 0, \"size\": 3699964, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e86df570f0d5ccf74a9194726045695ee4a45581453c0cd08f3a32bf968b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/20"
+    },
+    {
+        "type": "inline",
+        "contents": "ffb069ba945efc178619086e8153c69cdd46663a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz\", \"integrity\": \"sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==\", \"time\": 0, \"size\": 9669, \"metadata\": {\"url\": \"https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3079bcca5d7bd8c256de1438b61dfe2cddc828298501325a6aad84efdb25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/29"
     },
     {
         "type": "script",


### PR DESCRIPTION
## Summary

Updated the Flatpak dependency cache for the new v1.8 release. 

## Changes

- Regenerated `flatpak/node-modules.json` to include the new v1.8 NPM dependencies so the Flatpak builder doesn't fail.

## Testing

- [x] Manually verified on desktop
